### PR TITLE
Push images into subpath images.metal-pod.io/os.

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -48,4 +48,4 @@ jobs:
           --summary
           --no-lint
     - name: Upload image tarballs to GCS
-      run: cd images && gsutil -m cp -r . gs://$GCS_BUCKET/
+      run: cd images && gsutil -m cp -r . gs://$GCS_BUCKET/os


### PR DESCRIPTION
Reason for this is that we need to use a subpath in order to have the partition local image cache working. The local image cache contains other directories at root level such that they would be removed during sync.