### PR TITLE
Use backports linux-image for debian based images, fix firewall build…

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -107,6 +107,9 @@ RUN set -ex \
 
 COPY context/ /
 
+# Install backports kernel on debian because firewall requires kernel >= 5.x to make vxlan/evpn work
+RUN /kernel-installation.sh
+
 RUN /install-fits-ca.sh
 
 # Set default target to multi-user.target - otherwise it will be graphical.target

--- a/debian/context/kernel-installation.sh
+++ b/debian/context/kernel-installation.sh
@@ -6,7 +6,7 @@ if [ "${ID}" = "ubuntu" ] ; then
     echo "Ubuntu"
 else
     echo "Debian"
-    apt remove --yes linux-image-amd64
+    apt remove --yes linux-image*
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME}-backports main" > /etc/apt/sources.list.d/backports.list
     apt update --quiet
     apt install --yes -t buster-backports linux-image-amd64

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -37,9 +37,6 @@ RUN apt-get update --quiet \
 # - systemd.network configuration in `/etc/systemd/network` is used to apply network interface renaming in a bullet-proofed way
 COPY context/ /
 
-# Install backports kernel on debian because firewall requires kernel >= 5.x to make vxlan/evpn work
-RUN /kernel-installation.sh
-
 # Pre-Configure chrony instead of systemd-timesyncd because it is able to run in a VRF context without issues. 
 # Final setup is left to metal-networker that knows the internet-facing VRF.
 # To succeed metal-networker enabling chrony it is important to provide the chrony unit template in advance.

--- a/firewall/docker-make.yaml
+++ b/firewall/docker-make.yaml
@@ -1,8 +1,8 @@
 ---
 version: '1'
 name: firewall
-username: metalstack/images
-registry-host: ""
+username: metalstack
+registry-host: quay.io
 default-build-args:
   - http_proxy=${HTTP_PROXY}
   - https_proxy=${HTTP_PROXY}
@@ -19,7 +19,7 @@ builds:
       - ${SEMVER_MAJOR_MINOR}
     build-args:
       - BASE_OS_VERSION=10
-      - BASE_OS_NAME=metalstack/images/debian
+      - BASE_OS_NAME=quay.io/metalstack/debian
       - SEMVER_MAJOR_MINOR=2.0
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:
@@ -31,7 +31,7 @@ builds:
       - ${SEMVER_MAJOR_MINOR}
     build-args:
       - BASE_OS_VERSION=19.10
-      - BASE_OS_NAME=metalstack/images/ubuntu
+      - BASE_OS_NAME=quay.io/metalstack/ubuntu
       - SEMVER_MAJOR_MINOR=2.0-ubuntu
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:


### PR DESCRIPTION
… and push.

- Use backports kernel for debian and firewall-2
- remove standard linux image always
- fix firewall build and push for quay.io
