### PR TITLE
rotate suricata logs hourly

### DIFF
--- a/firewall/context/etc/logrotate.d/suricata
+++ b/firewall/context/etc/logrotate.d/suricata
@@ -1,9 +1,8 @@
 /var/log/suricata/*.log /var/log/suricata/*.json {
-    daily
+    hourly
     missingok
     rotate 5
     compress
-    delaycompress
     minsize 500k
     sharedscripts
 	postrotate


### PR DESCRIPTION
should prevent filling up the root partition