### PR TITLE
Update frr build with much newer libyang, also update lldpd

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -6,7 +6,7 @@ ARG METAL_NETWORKER_VERSION
 FROM metalstack/frr:${FRR_VERSION} AS frr-artifacts
 FROM metalstack/metal-networker:${METAL_NETWORKER_VERSION} as metal-networker
 
-FROM golang:1.14-buster as ignition-builder
+FROM golang:1.15-buster as ignition-builder
 ARG IGNITION_BRANCH
 WORKDIR /work
 RUN set -ex \

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -6,7 +6,7 @@ registry-host: quay.io
 default-build-args:
   - IGNITION_BRANCH=v0.35.0
   - YQ_VERSION=3.3.2
-  - GOLLDPD_VERSION=v0.2.4
+  - GOLLDPD_VERSION=v0.2.5
   - METAL_NETWORKER_VERSION=v0.3.0
   - SEMVER_PATCH=${SEMVER_PATCH}
   - BASE_OS_NAME=debian
@@ -22,7 +22,7 @@ builds:
     build-args:
       - BASE_OS_VERSION=10
       - DOCKER_APT_CHANNEL=buster
-      - FRR_VERSION=7.2-debian-10
+      - FRR_VERSION=7.2.1-1-debian-10
       - SEMVER_MAJOR_MINOR=10
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -6,7 +6,7 @@ registry-host: quay.io
 default-build-args:
   - IGNITION_BRANCH=v0.35.0
   - YQ_VERSION=3.3.2
-  - GOLLDPD_VERSION=v0.2.4
+  - GOLLDPD_VERSION=v0.2.5
   - METAL_NETWORKER_VERSION=v0.3.0
   - SEMVER_PATCH=${SEMVER_PATCH}
   - BASE_OS_NAME=ubuntu
@@ -22,7 +22,7 @@ builds:
       - ${SEMVER_MAJOR_MINOR}
     build-args:
       - BASE_OS_VERSION=20.04
-      - FRR_VERSION=7.2-ubuntu-20.04
+      - FRR_VERSION=7.2.1-1-ubuntu-20.04
       - SEMVER_MAJOR_MINOR=20.04
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:


### PR DESCRIPTION
- use the exact frr version build with the much newer libyang and rtrlib
- update lldpd build with golang 1.15 which saves 1MB of the image size
- ignition is build with golang 1.15 which should reduce the size even more

This depends on: https://github.com/metal-stack/frr/pull/3 to be merged first.