### PR TITLE
Fix obscure packet flow

### DIFF
--- a/centos/context/install.sh
+++ b/centos/context/install.sh
@@ -126,3 +126,7 @@ kernel: ${KERNEL}
 bootloader_id: ${BOOTLOADER_ID}
 ...
 REBOOT
+
+# Unset the machine-id (most importantly to avoid fixed MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
+echo "" > /etc/machine-id
+echo "" > /var/lib/dbus/machine-id

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -128,6 +128,3 @@ RUN systemctl set-default multi-user.target \
 
 # Provide metal-networker that is called during the install routine to setup networking.
 COPY --from=metal-networker /metal-networker /etc/metal/networker/
-
-# Unset the machine-id (most importantly to avoid persistent MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
-RUN echo "" > /etc/machine-id && echo "" > /var/lib/dbus/machine-id

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -128,3 +128,6 @@ RUN systemctl set-default multi-user.target \
 
 # Provide metal-networker that is called during the install routine to setup networking.
 COPY --from=metal-networker /metal-networker /etc/metal/networker/
+
+# Unset the machine-id (most importantly to avoid persistent MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
+RUN echo "" > /etc/machine-id && echo "" > /var/lib/dbus/machine-id

--- a/debian/context/install.sh
+++ b/debian/context/install.sh
@@ -144,6 +144,6 @@ else
     exit 1
 fi
 
-# Unset the machine-id (most importantly to avoid persistent MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
+# Unset the machine-id (most importantly to avoid fixed MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
 echo "" > /etc/machine-id
 echo "" > /var/lib/dbus/machine-id

--- a/debian/context/install.sh
+++ b/debian/context/install.sh
@@ -143,3 +143,7 @@ else
     echo "System was booted with Bios which is unsupported"
     exit 1
 fi
+
+# Unset the machine-id (most importantly to avoid persistent MAC addresses of interfaces - otherwise packets will arrive at unintended places!)
+echo "" > /etc/machine-id
+echo "" > /var/lib/dbus/machine-id

--- a/test/inputs/goss.yaml
+++ b/test/inputs/goss.yaml
@@ -25,6 +25,12 @@ file:
     exists: true
     contains:
     - {{ .Env.PUB_KEY }}
+  "/etc/machine-id":
+    exists: true
+    size: 1
+  "/var/lib/dbus/machine-id":
+    exists: true
+    size: 1
 {{ if eq .Env.MACHINE_TYPE "machine" }}
   "/var/lib/cloud-config-downloader/credentials/server":
     exists: true

--- a/test/inputs/goss.yaml
+++ b/test/inputs/goss.yaml
@@ -25,12 +25,6 @@ file:
     exists: true
     contains:
     - {{ .Env.PUB_KEY }}
-  "/etc/machine-id":
-    exists: true
-    size: 1
-  "/var/lib/dbus/machine-id":
-    exists: true
-    size: 1
 {{ if eq .Env.MACHINE_TYPE "machine" }}
   "/var/lib/cloud-config-downloader/credentials/server":
     exists: true


### PR DESCRIPTION
In our test environment we saw packets arriving at firewalls with addresses that were not advertised by the firewall.

This was caused by network interfaces having the same MAC addresses at the VTEPs of a Layer-3 VN:

```
# firewall 1
9: vrf104009: <NOARP,MASTER,UP,LOWER_UP> mtu 65536 qdisc noqueue state UP group default qlen 1000
    link/ether 3e:70:f7:29:41:da brd ff:ff:ff:ff:ff:ff
11: vni104009: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN group default qlen 1000
    link/ether 06:43:c1:f2:8c:ee brd ff:ff:ff:ff:ff:ff
13: vlan104009@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master vrf104009 state UP group default qlen 1000
    link/ether 06:43:c1:f2:8c:ee brd ff:ff:ff:ff:ff:ff

# firewall 2
7: vrf104009: <NOARP,MASTER,UP,LOWER_UP> mtu 65536 qdisc noqueue state UP group default qlen 1000
    link/ether 3e:70:f7:29:41:da brd ff:ff:ff:ff:ff:ff
9: vni104009: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master bridge state UNKNOWN group default qlen 1000
    link/ether 06:43:c1:f2:8c:ee brd ff:ff:ff:ff:ff:ff
12: vlan104009@bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc noqueue master vrf104009 state UP group default qlen 1000
    link/ether 06:43:c1:f2:8c:ee brd ff:ff:ff:ff:ff:ff
```

The solution is to provide an empty machine id to systemd. systemd will then generate a new one on the first startup and use it together with the interface name to generate a mac address. 

/cc @mwennrich @majst01 