### PR TITLE
nvme_core.io_timeout is not supported with kernel 4.14

### DIFF
--- a/centos/context/install.sh
+++ b/centos/context/install.sh
@@ -28,7 +28,7 @@ readonly ROOT_FS=$(jq -r '.Partitions[] | select(.Label=="root").Filesystem' "$d
 readonly VARLIB_UUID=$(jq -r '.Partitions[] | select(.Label=="varlib").Properties.UUID' "$diskjson")
 readonly VARLIB_FS=$(jq -r '.Partitions[] | select(.Label=="varlib").Filesystem' "$diskjson")
 
-readonly CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/usr/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295"
+readonly CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/usr/sbin/init net.ifnames=0 biosdevname=0"
 
 # only add /var/lib filesystem if created.
 VARLIB=""


### PR DESCRIPTION
This option causes an error in kernel 4.14 which we need in centos:
```
[root@storage-2 ~]# modprobe -D nvme
insmod /lib/modules/4.14.175-201276d5f9768199-rel-lb/extra/nvme-core.ko io_timeout=4294967295 
insmod /lib/modules/4.14.175-201276d5f9768199-rel-lb/extra/nvme.ko 
[root@storage-2 ~]# insmod /lib/modules/4.14.175-201276d5f9768199-rel-lb/extra/nvme-core.ko io_timeout=4294967295
insmod: ERROR: could not insert module /lib/modules/4.14.175-201276d5f9768199-rel-lb/extra/nvme-core.ko: Numerical result out of range
```