### PR TITLE
set systemd.unified_cgroup_hierarchy=0

### DIFF
--- a/debian/context/install.sh
+++ b/debian/context/install.sh
@@ -38,7 +38,7 @@ readonly ROOT_FS=$(jq -r '.Partitions[] | select(.Label=="root").Filesystem' "$d
 readonly VARLIB_UUID=$(jq -r '.Partitions[] | select(.Label=="varlib").Properties.UUID' "$diskjson")
 readonly VARLIB_FS=$(jq -r '.Partitions[] | select(.Label=="varlib").Filesystem' "$diskjson")
 
-readonly CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/bin/systemd net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295"
+readonly CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/bin/systemd net.ifnames=0 biosdevname=0 nvme_core.io_timeout=4294967295 systemd.unified_cgroup_hierarchy=0"
 
 # only add /var/lib filesystem if created.
 VARLIB=""


### PR DESCRIPTION
set `systemd.unified_cgroup_hierarchy=0`
enables kubelet with cgroupfs on newer debian kernels