### PR TITLE
Mitigate #87

### DIFF
--- a/debian/context/etc/sysctl.d/99-frr_defaults.conf
+++ b/debian/context/etc/sysctl.d/99-frr_defaults.conf
@@ -51,9 +51,5 @@ net.ipv6.neigh.default.base_reachable_time_ms=14400000
 # Use neigh information on selection of nexthop for multipath hops
 net.ipv4.fib_multipath_use_neigh=1
 
-# Use layer 4 information (ports) for multipath hashing
-net.ipv4.fib_multipath_hash_policy=1
-net.ipv6.fib_multipath_hash_policy=1
-
 # Allows Apps to Work with VRF
 net.ipv4.tcp_l3mdev_accept=1

--- a/firewall/context/etc/sysctl.d/99-multipath.conf
+++ b/firewall/context/etc/sysctl.d/99-multipath.conf
@@ -1,0 +1,3 @@
+# Use layer 4 information (ports) for multipath hashing
+net.ipv4.fib_multipath_hash_policy=1
+net.ipv6.fib_multipath_hash_policy=1

--- a/test/inputs/goss.yaml
+++ b/test/inputs/goss.yaml
@@ -192,5 +192,17 @@ kernel-param:
     value: "0"
   net.ipv4.conf.default.rp_filter:
     value: "0"
+{{ if eq .Env.MACHINE_TYPE "machine" }}
+  net.ipv4.fib_multipath_hash_policy:
+    value: "0"
+  net.ipv6.fib_multipath_hash_policy:
+    value: "0"
+{{ end }}
+{{ if eq .Env.MACHINE_TYPE "firewall" }}
+  net.ipv4.fib_multipath_hash_policy:
+    value: "1"
+  net.ipv6.fib_multipath_hash_policy:
+    value: "1"
+{{ end }}
   kernel.printk:
     value: "2\t4\t1\t7"


### PR DESCRIPTION
deactivate multipath hashing with l4 information for worker / normal machine images since we encounter issues with kernel > 5.8 and connection tracking

reference to #87 