### PR TITLE
Remove workarounds and FIXMEs

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -63,12 +63,6 @@ RUN curl -fLsS ${YQ_DOWNLOAD}/${YQ_VERSION}/yq_linux_amd64 -o ${YQ} \
  && yum install -y docker-ce docker-ce-cli containerd.io \
  && echo "LANG=\"en_US.UTF-8\"" > /etc/default/locale \
  && cp /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
- # Ensure that there exists a link from /usr/bin/python to python2
- # This is needed for ifupdown2 since they have /usr/bin/python as interpreter: https://github.com/CumulusNetworks/ifupdown2/blob/master/ifupdown2/__main__.py#L1
- # - with Ubuntu >= 20.04 this link does not exist anymore
- # - Debian Testing removed ifupdown2 from the repo: https://tracker.debian.org/news/1064997/ifupdown2-removed-from-testing/
- # - but a python3 based ifupdown2 version is on the way: https://github.com/CumulusNetworks/ifupdown2/issues/126
- && ln -sf /usr/bin/python2 /usr/bin/python \
  && rm -rf /tmp/*
 
 # Install FRR see https://rpm.frrouting.org/ for available channels

--- a/debian/context/install.sh
+++ b/debian/context/install.sh
@@ -58,7 +58,6 @@ EOM
 cat /etc/fstab
 
 # create a user/pass (metal:metal) to enable login
-# TODO move to Dockerfile
 readonly user="metal"
 readonly pass=$(yq e '.password' "$INSTALL_YAML")
 readonly devmode=$(yq e '.devmode' "$INSTALL_YAML")

--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -2,9 +2,11 @@
 set -e
 source /etc/os-release
 
+ADDITIONAL_PACKAGES="openssh-server systemd-timesyncd intel-microcode"
+
 if [ "${ID}" = "ubuntu" ] ; then
     echo "Ubuntu - Install kernel, openssh-server and systemd-timesyncd from ubuntu repository"
-    apt-get install --yes "linux-generic-hwe-${SEMVER_MAJOR_MINOR}" openssh-server systemd-timesyncd
+    apt-get install --yes "linux-generic-hwe-${SEMVER_MAJOR_MINOR}" ${ADDITIONAL_PACKAGES}
 else
     echo "Debian - Install kernel, openssh-server and systemd-timesyncd from backports repository"
     # Note: for firewall images the backports kernel is a hard requirements because kernel >= 5.x is necessary for vxlan/evpn
@@ -20,7 +22,7 @@ else
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME} contrib" > /etc/apt/sources.list.d/contrib.list
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME}-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list
     apt-get update --quiet
-    apt-get install --yes -t buster-backports openssh-server systemd-timesyncd intel-microcode
+    apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES}
     echo "deb https://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list
     apt-get update --quiet
     apt-get install --yes -t testing linux-image-amd64

--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -26,6 +26,8 @@ else
     echo "deb https://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list
     apt-get update --quiet
     apt-get install --yes -t testing linux-image-amd64
+    # remove testing list, otherwise doing update on the machine will show 100s of missing updates.
+    rm -f /etc/apt/sources.list.d/testing.list
 fi
 
 # Remove WIFI, netronome, v4l and liquidio firmware to save ~300MB image size

--- a/firewall/context/suricata-and-chrony-installation.sh
+++ b/firewall/context/suricata-and-chrony-installation.sh
@@ -15,12 +15,7 @@ else
     # chrony from main does not play well with newer kernels and exits sometimes.
     echo "deb https://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list
     apt-get update --quiet
-    # FIXME remove the sed and the || true once the installation do not break with:
-    # E: Could not configure 'libc6:amd64'.
-    # this removes the second line in the postinst script with in turn is "set -e"
-    sed -i '2d' /var/lib/dpkg/info/libc6\:amd64.postinst
-    apt-get install --yes --no-install-recommends -t testing chrony suricata suricata-update nftables || true
-    apt-get --fix-broken install || true
+    apt-get install --yes --no-install-recommends -t testing chrony suricata suricata-update nftables
     # remove testing list, otherwise doing update on the machine will show 100s of missing updates.
     rm -f /etc/apt/sources.list.d/testing.list
 fi


### PR DESCRIPTION
In this PR we have:

- Not needed link from python to python2 in centos
- ugly workaround for packages from testing not install-able

Also reviewed which packages get installed either from `testing` or `buster-backports` in debian. From my POV this should be fine atm.

I tested to set `bullseye` instead of `testing`, but this is not possible

TODO:
- [x] test centos and firewall