### PR TITLE
install kernel from bullseye instead of buster-testing

### DIFF
--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -22,12 +22,7 @@ else
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME} contrib" > /etc/apt/sources.list.d/contrib.list
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME}-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list
     apt-get update --quiet
-    apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES}
-    echo "deb https://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list
-    apt-get update --quiet
-    apt-get install --yes -t testing linux-image-amd64
-    # remove testing list, otherwise doing update on the machine will show 100s of missing updates.
-    rm -f /etc/apt/sources.list.d/testing.list
+    apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES} linux-image-amd64
 fi
 
 # Remove WIFI, netronome, v4l and liquidio firmware to save ~300MB image size

--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -21,8 +21,11 @@ else
     # audit: type=1326 audit(1595317960.526:2): auid=4294967295 uid=107 gid=65534 ses=4294967295 subj=kernel pid=1177 comm="sshd" exe="/usr/sbin/sshd" sig=31 arch=c000003e syscall=230 compat=0 ip=0x7fc40d5eebea code=0x0
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME} contrib" > /etc/apt/sources.list.d/contrib.list
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME}-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list
+    echo "deb https://deb.debian.org/debian bullseye main contrib non-free" > /etc/apt/sources.list.d/bullseye.list
     apt-get update --quiet
-    apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES} linux-image-amd64
+    apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES}
+    apt-get install --yes linux-image-amd64
+    rm -f /etc/apt/sources.list.d/bullseye.list
 fi
 
 # Remove WIFI, netronome, v4l and liquidio firmware to save ~300MB image size


### PR DESCRIPTION
since debian 11 was released, debian testing channel now ships kernel 5.14.x which breaks nvme-tcp. debian backports still has kernel 5.10 which works fine.

Once: https://github.com/torvalds/linux/commit/9edceaf43050f5ba1dd7d0011bcf68a736a17743 is merged in 5.14 we could probably use this kernel again.