### PR TITLE
mainline kernel for ubuntu and ubuntu firewall

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -76,9 +76,4 @@ jobs:
           --summary \
           --no-lint \
           --no-push
-    - uses: google-github-actions/setup-gcloud@master
-      with:
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-    - name: Upload image tarballs to GCS
-      run: cd images && gsutil -m cp -r . gs://$GCS_BUCKET/metal-os
+

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   GCS_BUCKET: images.metal-pod.io
@@ -32,7 +33,8 @@ jobs:
           --file docker-make.${{ matrix.os }}.yaml \
           --no-cache \
           --summary \
-          --no-lint
+          --no-lint \
+          --no-push
     - name: Build docker image for firewalls and export tarball
       run: |
         DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
@@ -44,7 +46,8 @@ jobs:
           --no-cache \
           --no-pull \
           --summary \
-          --no-lint
+          --no-lint \
+          --no-push
       if: ${{ matrix.os == 'ubuntu' }}
     - uses: google-github-actions/setup-gcloud@master
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Pipeline
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  GCS_BUCKET: images.metal-pod.io
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+jobs:
+  debian_ubuntu:
+    name: Build Debian and Ubuntu based OS images
+    strategy:
+      matrix:
+        os: [debian, ubuntu]
+    runs-on: self-hosted
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Prepare build environment
+      shell: bash
+      run: ./prepare.sh ${{ matrix.os }}
+    - name: Build docker image for workers and export tarball
+      run: |
+        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
+        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
+        TMPDIR=/var/tmp \
+        docker-make \
+          --work-dir debian \
+          --file docker-make.${{ matrix.os }}.yaml \
+          --no-cache \
+          --summary \
+          --no-lint
+    - name: Build docker image for firewalls and export tarball
+      run: |
+        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
+        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
+        TMPDIR=/var/tmp \
+        docker-make \
+          --work-dir firewall \
+          --build-only ${{ matrix.os }} \
+          --no-cache \
+          --no-pull \
+          --summary \
+          --no-lint
+      if: ${{ matrix.os == 'ubuntu' }}
+    - uses: google-github-actions/setup-gcloud@master
+      with:
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+    - name: Upload image tarballs to GCS
+      run: cd images && gsutil -m cp -r . gs://$GCS_BUCKET/metal-os
+  centos:
+    name: Build Centos based OS image
+    runs-on: self-hosted
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Prepare build environment
+      shell: bash
+      run: ./prepare.sh centos
+    - name: Build docker image for centos based workers and export tarball
+      run: |
+        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
+        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
+        TMPDIR=/var/tmp \
+        docker-make \
+          --work-dir centos \
+          --file docker-make.yaml \
+          --no-cache \
+          --summary \
+          --no-lint
+    - uses: google-github-actions/setup-gcloud@master
+      with:
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+    - name: Upload image tarballs to GCS
+      run: cd images && gsutil -m cp -r . gs://$GCS_BUCKET/metal-os

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -28,13 +28,15 @@ ARG DOCKER_APT_CHANNEL
 ARG CRI_VERSION
 ARG SEMVER_MAJOR_MINOR
 ARG KERNEL_VERSION
+ARG UBUNTU_MAINLINE_KERNEL_VERSION
 
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     YQ_DOWNLOAD=https://github.com/mikefarah/yq/releases/download \
     YQ=/usr/local/bin/yq \
     DOCKER_URL=https://download.docker.com \
-    SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR}
+    SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} \
+    UBUNTU_MAINLINE_KERNEL_VERSION=${UBUNTU_MAINLINE_KERNEL_VERSION}
 
 COPY context/etc/initramfs-tools/conf.d/ /etc/initramfs-tools/conf.d/
 COPY --from=frr-artifacts /artifacts/*.deb /tmp/

--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -6,7 +6,19 @@ ADDITIONAL_PACKAGES="openssh-server systemd-timesyncd intel-microcode"
 
 if [ "${ID}" = "ubuntu" ] ; then
     echo "Ubuntu - Install kernel, openssh-server and systemd-timesyncd from ubuntu repository"
-    apt-get install --yes "linux-generic-hwe-${SEMVER_MAJOR_MINOR}" ${ADDITIONAL_PACKAGES}
+    # Download mainline kernel packages, kernel up to 5.13 available in ubuntu 20.04 and 22.04 have a broken NAT implementation.
+    cd /tmp
+    wget --no-directories \
+         --no-parent \
+         --accept-regex generic \
+         --recursive \
+         --execute robots=off \
+        https://kernel.ubuntu.com/~kernel-ppa/mainline/${UBUNTU_MAINLINE_KERNEL_VERSION}/amd64/
+
+    apt-get install --yes \
+        /tmp/linux-image* \
+        /tmp/linux-modules* \
+        ${ADDITIONAL_PACKAGES}
 else
     echo "Debian - Install kernel, openssh-server and systemd-timesyncd from backports repository"
     # Note: for firewall images the backports kernel is a hard requirements because kernel >= 5.x is necessary for vxlan/evpn
@@ -35,4 +47,5 @@ rm -rf /usr/lib/firmware/*wifi* \
     /usr/lib/firmware/netronome \
     /usr/lib/firmware/v4l* \
     /usr/lib/firmware/liquidio \
-    /var/lib/apt/lists/*
+    /var/lib/apt/lists/* \
+    /tmp/*

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -6,13 +6,13 @@ registry-host: quay.io
 default-build-args:
   - IGNITION_BRANCH=v0.35.0
   - YQ_VERSION=v4.6.3
-  - GOLLDPD_VERSION=v0.3.5
+  - GOLLDPD_VERSION=v0.3.6
   - METAL_NETWORKER_VERSION=v0.7.2
   - SEMVER_PATCH=${SEMVER_PATCH}
   - BASE_OS_NAME=debian
   - OS_NAME=debian
   - DOCKER_APT_OS=debian
-  - CRI_VERSION=v1.21.0
+  - CRI_VERSION=v1.22.0
 builds:
   -
     name: "Debian 10"

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -13,7 +13,8 @@ default-build-args:
   - OS_NAME=ubuntu
   - DOCKER_APT_OS=ubuntu
   - DOCKER_APT_CHANNEL=focal
-  - CRI_VERSION=v1.21.0
+  - CRI_VERSION=v1.22.0
+  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.15.14
 builds:
   -
     name: "Ubuntu 20.04"

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -14,7 +14,7 @@ default-build-args:
   - DOCKER_APT_OS=ubuntu
   - DOCKER_APT_CHANNEL=focal
   - CRI_VERSION=v1.22.0
-  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.15.14
+  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.10.92
 builds:
   -
     name: "Ubuntu 20.04"

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -12,26 +12,13 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NODE_EXPORTER_VERSION=1.3.1 \
-    NFTABLES_EXPORTER_VERSION=v0.1.4 \
-    UBUNTU_MAINLINE_KERNEL_VERSION=v5.15.14
-
-# Download mainline kernel packages, kernel up to 5.13 available in ubuntu 20.04 and 22.04 have a broken NAT implementation.
-RUN cd /tmp \
- && wget --no-directories \
-         --no-parent \
-         --accept-regex generic \
-         --recursive \
-         --execute robots=off \
-    https://kernel.ubuntu.com/~kernel-ppa/mainline/${UBUNTU_MAINLINE_KERNEL_VERSION}/amd64/
+    NFTABLES_EXPORTER_VERSION=v0.1.4
 
 RUN apt-get update --quiet \
  && apt-get install --yes \
     bridge-utils \
     fever \
-    /tmp/linux-image* \
-    /tmp/linux-modules* \
     tcpdump \
- && apt-get remove --yes iptables linux-generic-hwe-${SEMVER_MAJOR_MINOR} \
  && apt --yes autoremove
 
 # Context:

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update --quiet \
     bridge-utils \
     fever \
     tcpdump \
+ && apt-get remove --yes iptables \
  && apt --yes autoremove
 
 # Context:

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -12,14 +12,24 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NODE_EXPORTER_VERSION=1.3.1 \
-    NFTABLES_EXPORTER_VERSION=v0.1.4
+    NFTABLES_EXPORTER_VERSION=v0.1.4 \
+    UBUNTU_MAINLINE_KERNEL_VERSION=v5.15.14
+
+# Download mainline kernel packages, kernel up to 5.13 available in ubuntu 20.04 and 22.04 have a broken NAT implementation.
+RUN cd /tmp \
+ && wget --no-directories \
+         --no-parent \
+         --accept-regex generic \
+         --recursive \
+         --execute robots=off \
+    https://kernel.ubuntu.com/~kernel-ppa/mainline/${UBUNTU_MAINLINE_KERNEL_VERSION}/amd64/
 
 RUN apt-get update --quiet \
  && apt-get install --yes \
     bridge-utils \
     fever \
-    # install kernel from ubuntu 22.04 because 5.11.0-46 breaks masquerading
-    linux-generic-hwe-${SEMVER_MAJOR_MINOR}-edge \
+    /tmp/linux-image* \
+    /tmp/linux-modules* \
     tcpdump \
  && apt-get remove --yes iptables linux-generic-hwe-${SEMVER_MAJOR_MINOR} \
  && apt --yes autoremove

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_OS_NAME
 ARG BASE_OS_VERSION
-ARG DROPTAILER_VERSION=v0.2.7
-ARG FIREWALL_CONTROLLER_VERSION=v1.0.9
+ARG DROPTAILER_VERSION=v0.2.8
+ARG FIREWALL_CONTROLLER_VERSION=v1.1.3
 
 FROM ghcr.io/metal-stack/droptailer-client:${DROPTAILER_VERSION} AS droptailer-artifacts
 
@@ -11,15 +11,17 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
-    NODE_EXPORTER_VERSION=1.1.2 \
-    NFTABLES_EXPORTER_VERSION=v0.1.3
+    NODE_EXPORTER_VERSION=1.3.1 \
+    NFTABLES_EXPORTER_VERSION=v0.1.4
 
 RUN apt-get update --quiet \
  && apt-get install --yes \
     bridge-utils \
     fever \
+    # install kernel from ubuntu 22.04 because 5.11.0-46 breaks masquerading
+    linux-generic-hwe-${SEMVER_MAJOR_MINOR}-edge \
     tcpdump \
- && apt-get remove --yes iptables \
+ && apt-get remove --yes iptables linux-generic-hwe-${SEMVER_MAJOR_MINOR} \
  && apt --yes autoremove
 
 # Context:


### PR DESCRIPTION
Because ubuntu kernels since 5.11.0-46 break MASQUERADE and the 5.13.x from ubuntu 22.04 has the same bug, we use the LTS Mainline kernel version for ubuntu and firewall-ubuntu from now on.

This kernel version must be updated explicitly on a regular basis.

With this commit these components where also updated:

- droptailer-server
- go-lldpd
- netfilter-exporter
- node-exporter
- cri-tools

