### PR TITLE
fix for cve-2022-0185

### DIFF
--- a/debian/context/kernel-and-timesyncd-installation.sh
+++ b/debian/context/kernel-and-timesyncd-installation.sh
@@ -34,6 +34,7 @@ else
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME} contrib" > /etc/apt/sources.list.d/contrib.list
     echo "deb https://deb.debian.org/debian ${VERSION_CODENAME}-backports main contrib non-free" > /etc/apt/sources.list.d/backports.list
     echo "deb https://deb.debian.org/debian bullseye main contrib non-free" > /etc/apt/sources.list.d/bullseye.list
+    echo "deb https://deb.debian.org/debian-security bullseye-security main contrib non-free" > /etc/apt/sources.list.d/bullseye-security.list
     apt-get update --quiet
     apt-get install --yes -t buster-backports ${ADDITIONAL_PACKAGES}
     # you can get list of installable versions with 

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -25,7 +25,7 @@ builds:
       - FRR_VERSION=7.5-debian-10
       - SEMVER_MAJOR_MINOR=10
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
-      - KERNEL_VERSION=5.10.92-1	
+      - KERNEL_VERSION=5.10.92-1
     after:
       - cd ../ && OS_NAME=${OS_NAME} ./test.sh quay.io/metalstack/${OS_NAME}:${SEMVER}
       - OS_NAME=${OS_NAME} SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} SEMVER_PATCH=${SEMVER_PATCH} ../export.sh

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -25,7 +25,7 @@ builds:
       - FRR_VERSION=7.5-debian-10
       - SEMVER_MAJOR_MINOR=10
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
-      - KERNEL_VERSION=5.10.84-1
+      - KERNEL_VERSION=5.10.92-1	
     after:
       - cd ../ && OS_NAME=${OS_NAME} ./test.sh quay.io/metalstack/${OS_NAME}:${SEMVER}
       - OS_NAME=${OS_NAME} SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} SEMVER_PATCH=${SEMVER_PATCH} ../export.sh

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -14,7 +14,7 @@ default-build-args:
   - DOCKER_APT_OS=ubuntu
   - DOCKER_APT_CHANNEL=focal
   - CRI_VERSION=v1.22.0
-  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.10.92
+  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.10.93
 builds:
   -
     name: "Ubuntu 20.04"

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -12,7 +12,7 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NODE_EXPORTER_VERSION=1.3.1 \
-    NFTABLES_EXPORTER_VERSION=v0.1.4
+    NFTABLES_EXPORTER_VERSION=v0.1.5
 
 RUN apt-get update --quiet \
  && apt-get install --yes \


### PR DESCRIPTION
- [x] wait for debian fix: https://security-tracker.debian.org/tracker/CVE-2022-0185