### PR TITLE
Fix upload paths.

### DIFF
--- a/centos/export.sh
+++ b/centos/export.sh
@@ -26,4 +26,4 @@ md5sum ${LZ4} > ${MD5}
 
 # export a list with the generated fqdn image names
 # mkdir -p workdir
-echo "${OS_NAME}-${SEMVER_MAJOR_MINOR}-${SEMVER_PATCH}" 
+echo "${OS_NAME}-${SEMVER_MAJOR_MINOR}-${SEMVER_PATCH}"

--- a/prepare.sh
+++ b/prepare.sh
@@ -4,16 +4,24 @@ set -e
 OS_FLAVOR=$1
 
 echo "Setting GitHub environment variables"
-echo "::set-env name=SEMVER_PATCH::$(date +%Y%m%d)"
 
 BRANCH=$(echo "${GITHUB_REF}" | awk -F / '{print $3}')
 echo "::set-env name=BRANCH::${BRANCH})"
+
 if [ -n "${GITHUB_BASE_REF}" ]; then
+    # this is a pull request build
     PULL_REQUEST_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
     BRANCH="${GITHUB_HEAD_REF##*/}"
     echo "::set-env name=OUTPUT_FOLDER::/${PULL_REQUEST_NUMBER}-${BRANCH}"
 else
-    echo "::set-env name=OUTPUT_FOLDER::/${BRANCH}"
+    if [ "$BRANCH" = "master" ]; then
+        # this is a build from stable branch
+        echo "::set-env name=OUTPUT_FOLDER::/stable"
+    else
+        # this is a release build
+        echo "::set-env name=SEMVER_PATCH::$(date +%Y%m%d)"
+        echo "::set-env name=OUTPUT_FOLDER::/"
+    fi
 fi
 
 echo "Generating build metadata"

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,10 @@ fi
 echo "import image oci to ignite: ${IMAGE}"
 sudo ignite stop "${VM_NAME}" || true
 sudo ignite rm "${VM_NAME}" || true
-sudo ignite image rm -f "${IMAGE}" || true
+# cleaning up all prior images to prevent ambigious image names
+for image in $(sudo ignite images -q); do
+  sudo ignite image rm -f "$image"
+done
 sudo ignite image import --runtime=docker --log-level debug "${IMAGE}"
 
 echo "create ignite / firecracker vm"


### PR DESCRIPTION
Unfortunately, over the time the upload paths became a bit messy.

I want to propose the following new paths:

| Type         | Current                                                               | New                                                          |
| ------------ | --------------------------------------------------------------------- | ------------------------------------------------------------ |
| Main Push    | `master/ubuntu/20.04/20220121/img.tar.lz4`*                     | `stable/ubuntu/20.04/img.tar.lz4`                     |
| Release      | `20220121/ubuntu/20.04/20220121/img.tar.lz4`                   | `ubuntu/20.04/20220121/img.tar.lz4`                   |
| Pull Request | `pull_requests/118-firewall-log-on-accept/debian/10/20220201/img.tar.lz4` | `pull_requests/118-firewall-log-on-accept/debian/10/img.tar.lz4` |

\* It once was without `master` in the path name, but at some point it changed.

Note that there is only a semver patch version (e.g. `20220201`) present on the release build. The other branches now will just overwrite existing targets, which makes these paths more stable over time and also it saves up some space.

Closes #119.