### PR TITLE
update kernels and containerd to fix 2 CVEs

### DIFF
--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -25,7 +25,7 @@ builds:
       - FRR_VERSION=7.5-debian-10
       - SEMVER_MAJOR_MINOR=10
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
-      - KERNEL_VERSION=5.10.92-1
+      - KERNEL_VERSION=5.10.92-2
     after:
       - cd ../ && OS_NAME=${OS_NAME} ./test.sh quay.io/metalstack/${OS_NAME}:${SEMVER}
       - OS_NAME=${OS_NAME} SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} SEMVER_PATCH=${SEMVER_PATCH} ../export.sh

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -14,7 +14,7 @@ default-build-args:
   - DOCKER_APT_OS=ubuntu
   - DOCKER_APT_CHANNEL=focal
   - CRI_VERSION=v1.22.0
-  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.10.93
+  - UBUNTU_MAINLINE_KERNEL_VERSION=v5.10.103
 builds:
   -
     name: "Ubuntu 20.04"


### PR DESCRIPTION
Containes:

- Fix for kernel [CVE-2022-0847](https://security-tracker.debian.org/tracker/CVE-2022-0847)
- Fix for containerd [CVE-2022-23648](https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7) with containerd v1.4.13