### PR TITLE
don't set fib_multipath_hash_policy=1 for firewalls

### DIFF
--- a/firewall/context/etc/sysctl.d/99-multipath.conf
+++ b/firewall/context/etc/sysctl.d/99-multipath.conf
@@ -1,3 +1,0 @@
-# Use layer 4 information (ports) for multipath hashing
-net.ipv4.fib_multipath_hash_policy=1
-net.ipv6.fib_multipath_hash_policy=1

--- a/test/inputs/goss.yaml
+++ b/test/inputs/goss.yaml
@@ -192,17 +192,9 @@ kernel-param:
     value: "0"
   net.ipv4.conf.default.rp_filter:
     value: "0"
-{{ if eq .Env.MACHINE_TYPE "machine" }}
   net.ipv4.fib_multipath_hash_policy:
     value: "0"
   net.ipv6.fib_multipath_hash_policy:
     value: "0"
-{{ end }}
-{{ if eq .Env.MACHINE_TYPE "firewall" }}
-  net.ipv4.fib_multipath_hash_policy:
-    value: "1"
-  net.ipv6.fib_multipath_hash_policy:
-    value: "1"
-{{ end }}
   kernel.printk:
     value: "2\t4\t1\t7"


### PR DESCRIPTION
`fib_multipath_hash_policy=1` breaks ECMP on the firewall, resulting in connection resets:

```
36:03:cd:6b:ee:18 > f8:8e:a1:f2:20:53, ethertype IPv4 (0x0800), length 66: 192.168.2.9.44348 > 172.11.22.206.443: Flags [.], ack 1880, win 501, options [nop,nop,TS val 2138234819 ecr 897279718], length 0
36:03:cd:6b:ee:18 > f8:8e:a1:f2:20:53, ethertype IPv4 (0x0800), length 66: 192.168.2.9.44348 > 172.11.22.206.443: Flags [.], ack 1946, win 501, options [nop,nop,TS val 2138234819 ecr 897279719], length 0
36:03:cd:6b:ee:18 > f8:8e:a1:f2:20:53, ethertype IPv4 (0x0800), length 97: 192.168.2.9.44348 > 172.11.22.206.443: Flags [P.], seq 2650:2681, ack 1946, win 501, options [nop,nop,TS val 2138234819 ecr 897279720], length 31

36:03:cd:6b:ee:18 > f8:8e:a1:f2:36:53, ethertype IPv4 (0x0800), length 66: 192.168.2.9.44348 > 172.11.22.206.443: Flags [.], ack 3294, win 501, options [nop,nop,TS val 2138234839 ecr 897279739], length 0
36:03:cd:6b:ee:18 > f8:8e:a1:f2:36:53, ethertype IPv4 (0x0800), length 66: 192.168.2.9.44348 > 172.11.22.206.443: Flags [.], ack 4642, win 501, options [nop,nop,TS val 2138234839 ecr 897279739], length 0
36:03:cd:6b:ee:18 > f8:8e:a1:f2:36:53, ethertype IPv4 (0x0800), length 66: 192.168.2.9.44348 > 172.11.22.206.443: Flags [.], ack 5990, win 501, options [nop,nop,TS val 2138234839 ecr 897279739], length 0
```
=> during the tcp-stream destination changed from `f8:8e:a1:f2:20:53` (vtep leaf01) to `f8:8e:a1:f2:36:53` (vtep leaf02)

related to issue https://github.com/metal-stack/metal-images/issues/87 where we already removed this for debian worker nodes
