### PR TITLE
disable l4 multipathing on firewalls

### DIFF
--- a/firewall/context/etc/sysctl.d/99-multipath.conf
+++ b/firewall/context/etc/sysctl.d/99-multipath.conf
@@ -1,3 +1,0 @@
-# Use layer 4 information (ports) for multipath hashing
-net.ipv4.fib_multipath_hash_policy=1
-net.ipv6.fib_multipath_hash_policy=1

--- a/test/inputs/goss.yaml
+++ b/test/inputs/goss.yaml
@@ -192,17 +192,9 @@ kernel-param:
     value: "0"
   net.ipv4.conf.default.rp_filter:
     value: "0"
-{{ if eq .Env.MACHINE_TYPE "machine" }}
   net.ipv4.fib_multipath_hash_policy:
     value: "0"
   net.ipv6.fib_multipath_hash_policy:
     value: "0"
-{{ end }}
-{{ if eq .Env.MACHINE_TYPE "firewall" }}
-  net.ipv4.fib_multipath_hash_policy:
-    value: "1"
-  net.ipv6.fib_multipath_hash_policy:
-    value: "1"
-{{ end }}
   kernel.printk:
     value: "2\t4\t1\t7"


### PR DESCRIPTION
L4 multipath hashing seems to cause issues with our ECMP-routing. We should disable it on the firewalls, too.