### PR TITLE
Enable CIS hardening for debian

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -125,6 +125,19 @@ RUN echo "---" >> /etc/metal/build-meta.yaml \
 
 COPY context/ /
 
+# Apply CIS hardening - we use https://github.com/ovh/debian-cis/ with a defined list to apply the config
+RUN mkdir /debian-cis \
+ && cd /debian-cis \
+ && curl -fLsS https://github.com/ovh/debian-cis/archive/refs/tags/latest.tar.gz -o cis-hardening.tar.gz \
+ && tar -xf cis-hardening.tar.gz --strip-components=1  \
+ && cp debian/default /etc/default/cis-hardening \
+ && sed -i "s#CIS_ROOT_DIR=.*#CIS_ROOT_DIR='$(pwd)'#" /etc/default/cis-hardening \
+ && bin/hardening.sh --audit --batch > /dev/null \
+ && bin/hardening.sh --audit --set-hardening-level 3 \
+ && cut -f 1 -d\# /cis-hardening.apply | while read a ; do bin/hardening.sh --apply --only "$a" ; done \
+ && rm /etc/default/cis-hardening \
+ && rm -rf /debian-cis
+
 # Copy the dependencies of `cloud-init-custom.service` into the image.
 COPY /cloud-init/cloud-init-custom.service /etc/systemd/system/
 COPY /cloud-init/cloud-init-custom.sh /etc/metal/

--- a/debian/context/cis-hardening.apply
+++ b/debian/context/cis-hardening.apply
@@ -1,0 +1,38 @@
+1.3.2     # Ensure sudo commands use pty
+1.3.3     # Ensure sudo log file exists
+1.6.4     # Ensure core dumps are restricted
+4.2.2.3   # Configure journald to write to a persistent location.
+4.2.3     # permissions on logs
+4.4       # Logrotate permissions
+5.2.1     # permissions and ownership to root 600 for sshd_config
+5.2.4     # Set secure shell (SSH) protocol to 2
+5.2.5     # Set LogLevel to INFO for SSH
+5.2.6     # Disable SSH X11 forwarding
+5.2.7     # Set SSH MaxAuthTries to 4
+5.2.8     # Set SSH IgnoreRhosts to Yes
+5.2.9     # Set SSH HostbasedAuthentication to No
+5.2.10    # Disable SSH Root Login
+5.2.11    # Set SSH PermitEmptyPasswords to No in order to disallow SSH login to accounts with empty password strigs
+5.2.12    # SSH Do not allow users to set environment options
+5.2.14    # SSH Message Authentication Code ciphers for preferred UMAC and SHA-256|512 with Encrypt-Then-Mac (etm)
+5.2.15    # SSH key exchange ciphers
+5.2.16    # SSH Set Idle Timeout Interval for user login
+5.2.17    # SSH Set Login Grace Time for user login
+5.2.18    # Limit access via SSH by (dis)allowing specific users or groups
+5.2.19    # Set SSH banner
+5.2.21    # Disable SSH AllowTCPForwarding
+5.2.22    # Configure SSHMaxStartups
+5.2.23    # Limit SSH MaxSessions
+# 5.3.1   # Set password creation requirement parameters using pam.cracklib
+5.3.2     # Set lockout for failed password attemps
+5.3.3     # Limit password reuse
+5.4.1.1   # Set password expiration days
+5.4.1.2   # Set password change minimum number of days
+5.4.4     # Set default mask for users to 077
+5.6       # Restrict access to su command
+99.1.1.23 # Disable USB devices
+99.3.3.3  # Create /etc/hosts.deny
+99.5.2.2  # Rekey limit for time (6 hours) or volume (512Mio) whichever comes first
+99.5.2.3  # all special features in sshd_config are disabled
+99.5.2.5  # Ensure home directory and ssh sensitive files are verified (not publicly readable) before connecting.
+99.5.2.8  # OpenSSH - UsePrivilegeSeparation set to sandbox.


### PR DESCRIPTION
In order to get a CIS compliant debian image, we need to make a few settings. To avoid much scripting I've used selected hardening scripts from ovh/debian-cis.