### PR TITLE
Copy release images from stable instead of rebuilding them.

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -66,9 +66,6 @@ jobs:
     - name: Upload image tarballs to GCS
       run: cd images && gsutil -m -h "Cache-Control:no-store" cp -r . gs://$GCS_BUCKET/metal-os
 
-    - uses: release-drafter/release-drafter@v5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   centos:
     name: Build Centos based OS image
     runs-on: self-hosted
@@ -96,4 +93,9 @@ jobs:
           --summary \
           --no-lint \
           --no-push
-
+    - uses: google-github-actions/setup-gcloud@v0
+      with:
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+    - name: Upload image tarballs to GCS
+      run: cd images && gsutil -m -h "Cache-Control:no-store" cp -r . gs://$GCS_BUCKET/metal-os

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,15 @@
+---
+name: Release Drafter Action
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: release-drafter/release-drafter@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,91 +7,15 @@ on:
 
 env:
   GCS_BUCKET: images.metal-pod.io
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
-  debian_ubuntu:
-    name: Build Debian and Ubuntu based OS images
-    strategy:
-      matrix:
-        os: [debian, ubuntu]
-    runs-on: self-hosted
+  copy:
+    name: Copy image tarballs from latest stable to release
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.20.x'
-    - name: Lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        args: --build-tags integration -p bugs -p unused --timeout=3m
-    - name: build install
-      run: make
-    - name: Prepare build environment
-      shell: bash
-      run: ./prepare.sh ${{ matrix.os }}
-    - name: Build docker image for workers and export tarball
-      run: |
-        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
-        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
-        TMPDIR=/var/tmp \
-        docker-make \
-          --work-dir debian \
-          --file docker-make.${{ matrix.os }}.yaml \
-          --no-cache \
-          --summary \
-          --no-lint
-    - name: Build docker image for firewalls and export tarball
-      run: |
-        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
-        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
-        TMPDIR=/var/tmp \
-        docker-make \
-          --work-dir firewall \
-          --build-only ${{ matrix.os }} \
-          --no-cache \
-          --no-pull \
-          --summary \
-          --no-lint
-      if: ${{ matrix.os == 'ubuntu' }}
     - uses: google-github-actions/setup-gcloud@v0
       with:
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
-    - name: Upload image tarballs to GCS
-      run: cd images && gsutil -m -h "Cache-Control:no-store" cp -r . gs://$GCS_BUCKET/metal-os
-  centos:
-    name: Build Centos based OS image
-    runs-on: self-hosted
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.20.x'
-    - name: build install
-      run: make
-    - name: Prepare build environment
-      shell: bash
-      run: ./prepare.sh centos
-    - name: Build docker image for centos based workers and export tarball
-      run: |
-        DOCKER_MAKE_REGISTRY_LOGIN_USER="metalstack+ci" \
-        DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${{ secrets.QUAY_IO_TOKEN }}" \
-        TMPDIR=/var/tmp \
-        docker-make \
-          --work-dir centos \
-          --file docker-make.yaml \
-          --no-cache \
-          --summary \
-          --no-lint \
-          --no-push
-    - uses: google-github-actions/setup-gcloud@v0
-      with:
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-    - name: Upload image tarballs to GCS
-      run: cd images && gsutil -m -h "Cache-Control:no-store" cp -r . gs://$GCS_BUCKET/metal-os
+
+    - run: |
+        gsutil -m cp -r gs://$GCS_BUCKET/metal-os/stable/ gs://$GCS_BUCKET/metal-os/${GITHUB_REF##*/}


### PR DESCRIPTION
As we do not have reproducible builds all the time, this seems to be a better variant for releasing images.

This changes the release paths from `/metal-os/<os>/<major>/<release-ref>/img.tar.lz4` to `/metal-os/<release-ref>/<os>/<major>/img.tar.lz4`.