### PR TITLE
Downgrade frr to distribution version for reliable EVPN

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -54,6 +54,7 @@ RUN set -ex \
     curl \
     dbus \
     efibootmgr \
+    frr \
     gettext-base \
     gnupg2 \
     gpg-agent \
@@ -103,11 +104,6 @@ RUN set -ex \
  # Switch to use iptables-legacy on worker nodes
  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
- # install frr from frrouting debian package repo
- && curl -fLsS https://deb.frrouting.org/frr/keys.asc | apt-key add - \
- && add-apt-repository "deb [arch=amd64] https://deb.frrouting.org/frr $(lsb_release -s -c) ${FRR_VERSION}" \
- && apt update \
- && apt install --yes --no-install-recommends frr=${FRR_VERSION_DETAIL} frr-pythontools=${FRR_VERSION_DETAIL} \
  # Install Intel Firmware for e800 based network cards
  && curl -fLsS https://sourceforge.net/projects/e1000/files/ice%20stable/${ICE_VERSION}/ice-${ICE_VERSION}.tar.gz/download -o ice.tar.gz \
  && tar -xf ice.tar.gz ice-${ICE_VERSION}/ddp/ice-${ICE_PKG_VERSION}.pkg \

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -23,7 +23,7 @@ builds:
       - BASE_OS_VERSION=11
       - DOCKER_APT_CHANNEL=bullseye
       - FRR_VERSION=frr-8
-      - FRR_VERSION_DETAIL=8.5.1-0~deb11u1
+      - FRR_VERSION_DETAIL=8.3.1-0~deb11u1
       - SEMVER_MAJOR_MINOR=11
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
       # see https://packages.debian.org/bullseye-backports/kernel/ for available versions

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -22,8 +22,6 @@ builds:
     build-args:
       - BASE_OS_VERSION=11
       - DOCKER_APT_CHANNEL=bullseye
-      - FRR_VERSION=frr-8
-      - FRR_VERSION_DETAIL=8.3.1-0~deb11u1
       - SEMVER_MAJOR_MINOR=11
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
       # see https://packages.debian.org/bullseye-backports/kernel/ for available versions

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -24,8 +24,6 @@ builds:
       - ${SEMVER_MAJOR_MINOR}
     build-args:
       - BASE_OS_VERSION=22.04
-      - FRR_VERSION=frr-8
-      - FRR_VERSION_DETAIL=8.3.1-0~ubuntu22.04.1
       - SEMVER_MAJOR_MINOR=22.04
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -13,7 +13,7 @@ default-build-args:
   - DOCKER_APT_CHANNEL=focal
   - CRI_VERSION=v1.26.1
   # see https://kernel.ubuntu.com/~kernel-ppa/mainline for available versions
-  - UBUNTU_MAINLINE_KERNEL_VERSION=v6.1.28
+  - UBUNTU_MAINLINE_KERNEL_VERSION=v6.1.30
   - ICE_VERSION=1.11.14
   - ICE_PKG_VERSION=1.3.30.0
 builds:
@@ -25,7 +25,7 @@ builds:
     build-args:
       - BASE_OS_VERSION=22.04
       - FRR_VERSION=frr-8
-      - FRR_VERSION_DETAIL=8.5.1-0~ubuntu22.04.1
+      - FRR_VERSION_DETAIL=8.3.1-0~ubuntu22.04.1
       - SEMVER_MAJOR_MINOR=22.04
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
     after:


### PR DESCRIPTION
We suffer from https://github.com/FRRouting/frr/issues/12391