### PR TITLE
Fix dracut command for CentOS with raid configuration.

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -672,7 +672,7 @@ GRUB_SERIAL_COMMAND="serial --speed=%s --unit=%s --word=8"`, i.oss.BootloaderID(
 				"--kmoddir", "/lib/modules/" + v,
 				"--include", "/lib/modules/" + v, "/lib/modules/" + v,
 				"--fstab",
-				`--add="dm mdraid"`,
+				`--add="mdraid"`,
 				`--add-drivers="raid0 raid1"`,
 				"--hostonly",
 				"--force",

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -667,13 +667,13 @@ GRUB_SERIAL_COMMAND="serial --speed=%s --unit=%s --word=8"`, i.oss.BootloaderID(
 		_, err = i.exec.command(&cmdParams{
 			name: "dracut",
 			args: []string{
-				"--mdadm",
+				"--mdadmconf",
 				"--kver", v,
 				"--kmoddir", "/lib/modules/" + v,
 				"--include", "/lib/modules/" + v, "/lib/modules/" + v,
 				"--fstab",
-				`--add="mdraid"`,
-				`--add-drivers="raid0 raid1"`,
+				"--add=dm mdraid",
+				"--add-drivers=raid0 raid1",
 				"--hostonly",
 				"--force",
 			},

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -865,7 +865,7 @@ GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"`,
 					ExitCode: 0,
 				},
 				{
-					WantCmd:  []string{"dracut", "--mdadm", "--kver", "1.2.3", "--kmoddir", "/lib/modules/1.2.3", "--include", "/lib/modules/1.2.3", "/lib/modules/1.2.3", "--fstab", "--add=\"mdraid\"", "--add-drivers=\"raid0 raid1\"", "--hostonly", "--force"},
+					WantCmd:  []string{"dracut", "--mdadmconf", "--kver", "1.2.3", "--kmoddir", "/lib/modules/1.2.3", "--include", "/lib/modules/1.2.3", "/lib/modules/1.2.3", "--fstab", "--add=dm mdraid", "--add-drivers=raid0 raid1", "--hostonly", "--force"},
 					Output:   "",
 					ExitCode: 0,
 				},

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -865,7 +865,7 @@ GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"`,
 					ExitCode: 0,
 				},
 				{
-					WantCmd:  []string{"dracut", "--mdadm", "--kver", "1.2.3", "--kmoddir", "/lib/modules/1.2.3", "--include", "/lib/modules/1.2.3", "/lib/modules/1.2.3", "--fstab", "--add=\"dm mdraid\"", "--add-drivers=\"raid0 raid1\"", "--hostonly", "--force"},
+					WantCmd:  []string{"dracut", "--mdadm", "--kver", "1.2.3", "--kmoddir", "/lib/modules/1.2.3", "--include", "/lib/modules/1.2.3", "/lib/modules/1.2.3", "--fstab", "--add=\"mdraid\"", "--add-drivers=\"raid0 raid1\"", "--hostonly", "--force"},
 					Output:   "",
 					ExitCode: 0,
 				},


### PR DESCRIPTION
The error message with the latest CentOS 7 image is:

``` 
:48.370+0200    info    cmdexec running command {"commmand": "dracut --mdadm --kver 3.10.0-1160.88.1.el7.x86_64 --kmoddir /lib/modules/3.10.0-1160.88.1.el7.x86_64 --include /lib/modules/3.10.0-1160.88.1.el7.x86_64 /lib/modules/3.10.0-1160.88.
1.el7.x86_64 --fstab --add=\"dm mdraid\" --add-drivers=\"raid0 raid1\" --hostonly --force", "start": "2023-06-12 11:18:48.370205355 +0200 CEST m=+2.620076500"}
No '/dev/log' or 'logger' included for syslog logging
findmnt: can't read (null): No such file or directory
findmnt: can't read (null): No such file or directory
cp: cannot stat '/proc/modules': No such file or directory
dracut module '"[  444.112690] dracut[1673] dracut module '"dm' cannot be found or installed.
dm' cannot be found or installed.
2023-06-12T11:18:49.420+0200    error   cmdexec executed command with error     {"output": "", "duration": "1.050703532s", "error": "exit status 1"}
2023-06-12T11:18:49.421+0200    error   install-go      installation failed     {"duration": 3.66659713}
2023-06-12T11:18:49.421+0200    fatal   install-go      exit status 1
```