### PR TITLE
Write /etc/resolv.conf during export

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -52,12 +52,6 @@ func (i *installer) do() error {
 		}
 	}
 
-	err = i.writeResolvConf()
-	if err != nil {
-		i.log.Warn("writing resolv.conf failed", "error", err)
-		return err
-	}
-
 	err = i.createMetalUser()
 	if err != nil {
 		return err
@@ -138,26 +132,6 @@ func (i *installer) fileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
-}
-
-func (i *installer) writeResolvConf() error {
-	i.log.Info("write /etc/resolv.conf")
-	// Must be written here because during docker build this file is synthetic
-	// FIXME enable systemd-resolved based approach again once we figured out why it does not work on the firewall
-	// most probably because the resolved must be running in the internet facing vrf.
-	// ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
-	// in ignite this file is a symlink to /proc/net/pnp, to pass integration test, remove this first
-	err := i.fs.Remove("/etc/resolv.conf")
-	if err != nil {
-		i.log.Info("no /etc/resolv.conf present")
-	}
-
-	// FIXME migrate to dns0.eu resolvers
-	content := []byte(
-		`nameserver 8.8.8.8
-nameserver 8.8.4.4
-`)
-	return afero.WriteFile(i.fs, "/etc/resolv.conf", content, 0644)
 }
 
 func (i *installer) buildCMDLine() string {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -206,58 +206,6 @@ func Test_installer_detectFirmware(t *testing.T) {
 	}
 }
 
-func Test_installer_writeResolvConf(t *testing.T) {
-	tests := []struct {
-		name    string
-		fsMocks func(fs afero.Fs)
-		want    string
-		wantErr error
-	}{
-		{
-			name: "resolv.conf gets written",
-			fsMocks: func(fs afero.Fs) {
-				require.NoError(t, afero.WriteFile(fs, "/etc/resolv.conf", []byte(""), 0755))
-			},
-			want: `nameserver 8.8.8.8
-nameserver 8.8.4.4
-`,
-			wantErr: nil,
-		},
-		{
-			name: "resolv.conf gets written, file is not present",
-			want: `nameserver 8.8.8.8
-nameserver 8.8.4.4
-`,
-			wantErr: nil,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			i := &installer{
-				log: slog.Default(),
-				fs:  afero.NewMemMapFs(),
-			}
-
-			if tt.fsMocks != nil {
-				tt.fsMocks(i.fs)
-			}
-
-			err := i.writeResolvConf()
-			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
-				t.Errorf("error diff (+got -want):\n %s", diff)
-			}
-
-			content, err := afero.ReadFile(i.fs, "/etc/resolv.conf")
-			require.NoError(t, err)
-
-			if diff := cmp.Diff(tt.want, string(content)); diff != "" {
-				t.Errorf("error diff (+got -want):\n %s", diff)
-			}
-		})
-	}
-}
-
 func Test_installer_fixPermissions(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/debian/context/etc/systemd/resolved.conf.d/dns.conf
+++ b/debian/context/etc/systemd/resolved.conf.d/dns.conf
@@ -1,3 +1,0 @@
-[Resolve]
-DNS=8.8.8.8 8.8.4.4
-LLMNR=no

--- a/debian/context/kernel-installation.sh
+++ b/debian/context/kernel-installation.sh
@@ -17,8 +17,6 @@ if [ "${ID}" = "ubuntu" ] ; then
         /tmp/linux-image* \
         /tmp/linux-modules* \
         intel-microcode
-    # Ubuntu still requires it
-    systemctl enable systemd-resolved
 else
     echo "Debian - Install kernel"
 

--- a/export.sh
+++ b/export.sh
@@ -18,6 +18,8 @@ readonly PKG="packages.txt"
 mkdir -p "${EXPORT_DIRECTORY}"
 cd "${EXPORT_DIRECTORY}"
 docker export "$(docker create "${DOCKER_IMAGE}")" > ${TAR}
+# set /etc/resolv.conf
+tar --file ${TAR} --directory=export --append etc
 docker run --rm "${DOCKER_IMAGE}" bash -c "dpkg -l" > ${PKG}
 lz4 -f -9 ${TAR} ${LZ4}
 rm -f ${TAR}

--- a/export/etc/resolv.conf
+++ b/export/etc/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 8.8.8.8
+nameserver 8.8.4.4


### PR DESCRIPTION
Allows third parties to set their own nameservers by modifying the resulting tars.