### PR TITLE
Do not compress and keep suricata logs on the firewall

### DIFF
--- a/firewall/context/etc/logrotate.d/suricata
+++ b/firewall/context/etc/logrotate.d/suricata
@@ -1,8 +1,6 @@
 /var/log/suricata/*.log /var/log/suricata/*.json {
     hourly
     missingok
-    rotate 5
-    compress
     minsize 500k
     sharedscripts
 	postrotate

--- a/firewall/context/etc/logrotate.d/suricata
+++ b/firewall/context/etc/logrotate.d/suricata
@@ -1,6 +1,7 @@
 /var/log/suricata/*.log /var/log/suricata/*.json {
     hourly
     missingok
+    rotate 0
     minsize 500k
     sharedscripts
 	postrotate


### PR DESCRIPTION
This will reduce Disk IO pressure on the firewall