### PR TITLE
Do not disable cgroupv2

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -257,7 +257,6 @@ func (i *installer) buildCMDLine() string {
 		"net.ifnames=0",
 		"biosdevname=0",
 		"nvme_core.io_timeout=300", // 300 sec should be enough for firewalls to be replaced
-		"systemd.unified_cgroup_hierarchy=0",
 	}
 
 	mdUUID, found := i.findMDUUID()

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -597,8 +597,8 @@ func Test_installer_buildCMDLine(t *testing.T) {
 					ExitCode: 0,
 				},
 			},
-			// CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0"
-			want: "console=ttyS1,115200n8 root=UUID=543eb7f8-98d4-d986-e669-824dbebe69e5 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0",
+			// CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300"
+			want: "console=ttyS1,115200n8 root=UUID=543eb7f8-98d4-d986-e669-824dbebe69e5 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300",
 		},
 		{
 			name: "with raid",
@@ -617,8 +617,8 @@ func Test_installer_buildCMDLine(t *testing.T) {
 					ExitCode: 0,
 				},
 			},
-			// CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0"
-			want: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0 rdloaddriver=raid0 rdloaddriver=raid1 rd.md.uuid=543eb7f8:98d4d986:e669824d:bebe69e5",
+			// CMDLINE="console=${CONSOLE} root=UUID=${ROOT_UUID} init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300"
+			want: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 rdloaddriver=raid0 rdloaddriver=raid1 rd.md.uuid=543eb7f8:98d4d986:e669824d:bebe69e5",
 		},
 	}
 	for _, tt := range tests {
@@ -891,7 +891,7 @@ func Test_installer_grubInstall(t *testing.T) {
 			fsMocks: func(fs afero.Fs) {
 				require.NoError(t, afero.WriteFile(fs, "/etc/metal/install.yaml", []byte(sampleInstallYAML), 0700))
 			},
-			cmdline: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0",
+			cmdline: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300",
 			oss:     osUbuntu,
 			execMocks: []fakeexecparams{
 				{
@@ -914,7 +914,7 @@ func Test_installer_grubInstall(t *testing.T) {
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=metal-ubuntu
 GRUB_CMDLINE_LINUX_DEFAULT=""
-GRUB_CMDLINE_LINUX="console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0"
+GRUB_CMDLINE_LINUX="console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300"
 GRUB_TERMINAL=serial
 GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"
 `,
@@ -924,7 +924,7 @@ GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"
 			fsMocks: func(fs afero.Fs) {
 				require.NoError(t, afero.WriteFile(fs, "/etc/metal/install.yaml", []byte(sampleInstallWithRaidYAML), 0700))
 			},
-			cmdline: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0",
+			cmdline: "console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300",
 			oss:     osUbuntu,
 			execMocks: []fakeexecparams{
 				{
@@ -972,7 +972,7 @@ GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=metal-ubuntu
 GRUB_CMDLINE_LINUX_DEFAULT=""
-GRUB_CMDLINE_LINUX="console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300 systemd.unified_cgroup_hierarchy=0"
+GRUB_CMDLINE_LINUX="console=ttyS1,115200n8 root=UUID=ace079b5-06be-4429-bbf0-081ea4d7d0d9 init=/sbin/init net.ifnames=0 biosdevname=0 nvme_core.io_timeout=300"
 GRUB_TERMINAL=serial
 GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=1 --word=8"
 `,

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -92,7 +92,8 @@ RUN set -ex \
  && curl -fLsS ${DOCKER_URL}/linux/${DOCKER_APT_OS}/gpg | apt-key add - \
  && echo "deb [arch=amd64] ${DOCKER_URL}/linux/${DOCKER_APT_OS} ${DOCKER_APT_CHANNEL} stable" > /etc/apt/sources.list.d/docker.list \
  && apt-get update \
- && apt-get install --yes --no-install-recommends containerd.io \
+ # FIXME remove once containerd v1.7.25 is released, 1.7.24 is broken because runc < 1.2.4 breaks TAP/TUN devices required for vpn-shoot
+ && apt-get install --yes --no-install-recommends containerd.io=1.7.23-1 \
  # Install crictl to be able to manipulate containers managed with containerd
  && curl -fLsS https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz -o /tmp/crictl-${CRI_VERSION}-linux-amd64.tar.gz \
  && tar -xf /tmp/crictl-${CRI_VERSION}-linux-amd64.tar.gz -C /usr/local/bin \

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -29,7 +29,7 @@ builds:
       - SEMVER_MAJOR_MINOR=12
       - SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
       # see https://packages.debian.org/bookworm/kernel/ for available versions
-      - KERNEL_VERSION=6.1.0-28
+      - KERNEL_VERSION=6.1.0-29
     after:
       - cd ../ && OS_NAME=${OS_NAME} CIS_VERSION=${CIS_VERSION} ./test.sh quay.io/metalstack/${OS_NAME}:${SEMVER}
       - OS_NAME=${OS_NAME} SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} SEMVER_PATCH=${SEMVER_PATCH} ../export.sh

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/metal-stack/metal-go v0.39.4
 	github.com/metal-stack/metal-hammer v0.13.10
 	github.com/metal-stack/metal-lib v0.19.0
-	github.com/metal-stack/metal-networker v0.45.3
+	github.com/metal-stack/metal-networker v0.45.4
 	github.com/metal-stack/v v1.0.3
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/spf13/afero v1.11.0
+	github.com/spf13/afero v1.12.0
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/metal-stack/metal-hammer v0.13.10 h1:p1L2rGeABbjv8jRnua7dYF8nDjLZ+Boh
 github.com/metal-stack/metal-hammer v0.13.10/go.mod h1:cOdArIOW1VBICPX3dlpyg1Wf3PsMeGjyw7mJJmCTqeU=
 github.com/metal-stack/metal-lib v0.19.0 h1:4yBnp/jPGgX9KeCje3A4MFL2oDjgjOjgsIK391LltRI=
 github.com/metal-stack/metal-lib v0.19.0/go.mod h1:fCMaWwVGA/xAoGvBk72/nfzqBkHly0iOzrWpc55Fau4=
-github.com/metal-stack/metal-networker v0.45.3 h1:GALlPsSMYw70vuQLcmwEEX9VNJVWkZk/4pP7eERD/VU=
-github.com/metal-stack/metal-networker v0.45.3/go.mod h1:DUjaql5THUSJd/7M1ZlcYgX/bllp1IhXwOFM+Nvkaus=
+github.com/metal-stack/metal-networker v0.45.4 h1:WJ/l+kKzL+/pamPl7DjYd1q+goHqjJ1sAhFgvzDVyfk=
+github.com/metal-stack/metal-networker v0.45.4/go.mod h1:DUjaql5THUSJd/7M1ZlcYgX/bllp1IhXwOFM+Nvkaus=
 github.com/metal-stack/v v1.0.3 h1:Sh2oBlnxrCUD+mVpzfC8HiqL045YWkxs0gpTvkjppqs=
 github.com/metal-stack/v v1.0.3/go.mod h1:YTahEu7/ishwpYKnp/VaW/7nf8+PInogkfGwLcGPdXg=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -161,8 +161,8 @@ github.com/sigma/bdoor v0.0.0-20160202064022-babf2a4017b0/go.mod h1:WBu7REWbxC/s
 github.com/sigma/vmw-guestinfo v0.0.0-20160204083807-95dd4126d6e8/go.mod h1:JrRFFC0veyh0cibh0DAhriSY7/gV3kDdNaVUOmfx01U=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
## Description

From Kubernetes 1.31 cgroupv1 goes into [maintenance mode](https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/). Stop disabling cgroupv2. 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
