### PR TITLE
Add a grype workflow for scheduled security scans

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -162,3 +162,30 @@ jobs:
 
     - name: Upload image tarballs to GCS
       run: cd images && gsutil -m -h "Cache-Control:no-store" cp -r . gs://$GCS_BUCKET/metal-os/pull_requests/
+
+    - name: 🛡️ Run Grype scan for debian
+      id: grype-scan-debian
+      uses: anchore/scan-action@v6
+      with:
+        image: ghcr.io/metal-stack/debian:latest
+        fail-build: false
+        additional-args: "-c .grype.yaml"
+        output-format: table
+        output-file: scan-results.md
+
+    - name: 📮 Create issue if vulnerabilities found in debian
+      if: ${{ failure() && steps.grype-scan-debian.outcome == 'failure' }}
+      uses: dacbd/create-issue-action@main
+      with:
+        token: ${{ github.token }}
+        title: "🛑 Alert for vulnerable packages in the debian image"
+        body: |
+          **Security scan detected fixed vulnerabilities**
+
+          '''
+          $ cat scan-results.md
+          '''
+          _Scan executed at: ${{ steps.date.outputs.timestamp }}_
+
+          Hint: This issue will be automatically closed once an image with no vulnerabilities is built.
+        labels: security,automated-alert,debian-vulnerability

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,26 @@ jobs:
 
           PREFIX=metal-os/${GITHUB_REF##*/} go run ./cmd/tools/generate-table > downloads.md
 
+      - name: Run Grype scan for debian
+        id: grype-scan-debian
+        uses: anchore/scan-action@v6
+        with:
+          image: ghcr.io/metal-stack/debian:latest
+          fail-build: false
+          additional-args: "-c .grype.yaml"
+          output-format: table
+
+      - name: Find issues for debian vulnerabilities
+        if: ${{ steps.grype-scan-debian.outcome == 'success' }}
+        id: debian-issues
+        uses: lee-dohm/select-matching-issues@v1
+        with:
+          query: 'label:debian-vulnerability'
+          token: ${{ github.token }}
+
+      - name: Close fixed vulnerability issues
+        run: cat ${{ steps.debian-issues.outputs.path }} | xargs gh issue close
+
       - name: Update release body
         id: update_release
         uses: tubone24/update_release@v1.3.1

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -1,0 +1,50 @@
+name: Scheduled Registry Scan
+
+on:
+  schedule:
+    - cron: '6 0 * * 1'  # Weekly scan on Monday 6am
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  issues: write
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔑 Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🛡️  Run Grype scan for debian
+        id: grype-scan-debian
+        uses: anchore/scan-action@v6
+        with:
+          image: ghcr.io/metal-stack/debian:latest
+          fail-build: false
+          additional-args: "-c .grype.yaml"
+          output-format: table
+          output-file: scan-results.md
+
+      - name: 📮 Create issue if vulnerabilities found in debian
+        if: ${{ failure() && steps.grype-scan-debian.outcome == 'failure' }}
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: "🛑 Vulnerability Alert for the debian image"
+          body: |
+            **Security scan detected fixed vulnerabilities**
+
+            '''
+            $ cat scan-results.md
+            '''
+            _Scan executed at: ${{ steps.date.outputs.timestamp }}_
+          labels: security,automated-alert

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ github.token }}
-          title: "🛑 Vulnerability Alert for the debian image"
+          title: "🛑 Alert for vulnerable packages in the debian image"
           body: |
             **Security scan detected fixed vulnerabilities**
 
@@ -47,4 +47,6 @@ jobs:
             $ cat scan-results.md
             '''
             _Scan executed at: ${{ steps.date.outputs.timestamp }}_
-          labels: security,automated-alert
+
+            Hint: This issue will be automatically closed once an image with no vulnerabilities is built.
+          labels: security,automated-alert,debian-vulnerability

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,8 @@
+# We only want to check for updated OS packages
+only-fixed: true
+
+ignore:
+ - package:
+     type: "go-module"
+ - package:
+     type: "linux-kernel"


### PR DESCRIPTION
## Description

This PR adds a new GitHub action that performs a weekly scan for outdated packages. If an outdated package with a medium+ vulnerability is found, the workflow creates a new issue in this repository.

For the moment, only the Debian image is scanned. Additional tasks for the other images should be added once this works.