### PR TITLE
remove SEMVER_PATCH_DIR from TARGET_PATH

### DIFF
--- a/almalinux/export.sh
+++ b/almalinux/export.sh
@@ -5,8 +5,7 @@ readonly SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
 readonly DOCKER_IMAGE="ghcr.io/metal-stack/${OS_NAME}:${SEMVER}"
 readonly IMAGE_BASENAME=img
 
-readonly SEMVER_PATCH_DIR=$(echo "${SEMVER_PATCH}" | tr -d ".")
-readonly TARGET_PATH="images${OUTPUT_FOLDER}/${OS_NAME}/${SEMVER_MAJOR_MINOR}/${SEMVER_PATCH_DIR}"
+readonly TARGET_PATH="images${OUTPUT_FOLDER}/${OS_NAME}/${SEMVER_MAJOR_MINOR}"
 readonly EXPORT_DIRECTORY="../${TARGET_PATH}"
 
 readonly TAR="${IMAGE_BASENAME}.tar"

--- a/export.sh
+++ b/export.sh
@@ -5,8 +5,7 @@ readonly SEMVER=${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}
 readonly DOCKER_IMAGE="ghcr.io/metal-stack/${OS_NAME}:${SEMVER}"
 readonly IMAGE_BASENAME=img
 
-readonly SEMVER_PATCH_DIR=$(echo "${SEMVER_PATCH}" | tr -d ".")
-readonly TARGET_PATH="images${OUTPUT_FOLDER}/${OS_NAME}/${SEMVER_MAJOR_MINOR}/${SEMVER_PATCH_DIR}"
+readonly TARGET_PATH="images${OUTPUT_FOLDER}/${OS_NAME}/${SEMVER_MAJOR_MINOR}"
 readonly EXPORT_DIRECTORY="../${TARGET_PATH}"
 
 readonly TAR="${IMAGE_BASENAME}.tar"
@@ -25,5 +24,4 @@ md5sum ${LZ4} > ${MD5}
 
 # export a list with the generated fqdn image names
 # mkdir -p workdir
-echo "${OS_NAME}-${SEMVER_MAJOR_MINOR}-${SEMVER_PATCH}" 
-
+echo "${OS_NAME}-${SEMVER_MAJOR_MINOR}-${SEMVER_PATCH}"


### PR DESCRIPTION
## Description

previous PR builds copied the image to following target path:
```
http://images.metal-stack.io/metal-os/pull_requests/309-fix-target-path/firewall/3.0-ubuntu/-fix-target-path/img.tar.lz4
```
This PR removes the duplicate branch name to instead:
```
http://images.metal-stack.io/metal-os/pull_requests/309-fix-target-path/firewall/3.0-ubuntu/img.tar.lz4
```

Same for stable images:

```plaintext
http://images.metal-stack.io/metal-os/stable/debian/12/img.tar.lz4
``` 
instead of
```plaintext
http://images.metal-stack.io/metal-os/stable/debian/12/-stable/img.tar.lz4
```