### PR TITLE
Do not break release, actual implementation of closing the issues was wrong

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,7 +169,6 @@ jobs:
       with:
         image: ghcr.io/metal-stack/debian:latest
         fail-build: false
-        additional-args: "-c .grype.yaml"
         output-format: table
         output-file: scan-results.md
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,26 +73,6 @@ jobs:
 
           PREFIX=metal-os/${GITHUB_REF##*/} go run ./cmd/tools/generate-table > downloads.md
 
-      - name: Run Grype scan for debian
-        id: grype-scan-debian
-        uses: anchore/scan-action@v6
-        with:
-          image: ghcr.io/metal-stack/debian:latest
-          fail-build: false
-          additional-args: "-c .grype.yaml"
-          output-format: table
-
-      - name: Find issues for debian vulnerabilities
-        if: ${{ steps.grype-scan-debian.outcome == 'success' }}
-        id: debian-issues
-        uses: lee-dohm/select-matching-issues@v1
-        with:
-          query: 'label:debian-vulnerability'
-          token: ${{ github.token }}
-
-      - name: Close fixed vulnerability issues
-        run: cat ${{ steps.debian-issues.outputs.path }} | xargs gh issue close
-
       - name: Update release body
         id: update_release
         uses: tubone24/update_release@v1.3.1

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           image: ghcr.io/metal-stack/debian:latest
           fail-build: false
-          additional-args: "-c .grype.yaml"
           output-format: table
           output-file: scan-results.md
 


### PR DESCRIPTION
## Description

This fixes the release pipeline, which must not happen because otherwise not all artifacts are visible.
see: https://github.com/metal-stack/metal-images/actions/runs/15294259709

The current implementation of closing existing was somehow wrong because the action did not succeed for unknown reason.
```
Run cat __matching-issues.txt | xargs gh issue close
  cat __matching-issues.txt | xargs gh issue close
  shell: /usr/bin/bash -e ***0***
  env:
    GCS_BUCKET: images.metal-pod.io
    CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: /home/runner/work/metal-images/metal-images/gha-creds-c9996174c8115c8d.json
    GOOGLE_APPLICATION_CREDENTIALS: /home/runner/work/metal-images/metal-images/gha-creds-c9996174c8115c8d.json
    GOOGLE_GHA_CREDS_PATH: /home/runner/work/metal-images/metal-images/gha-creds-c9996174c8115c8d.json
    CLOUDSDK_CORE_PROJECT: metal-control-plane
    CLOUDSDK_PROJECT: metal-control-plane
    GCLOUD_PROJECT: metal-control-plane
    GCP_PROJECT: metal-control-plane
    GOOGLE_CLOUD_PROJECT: metal-control-plane
    CLOUDSDK_METRICS_ENVIRONMENT: github-actions-setup-gcloud
    CLOUDSDK_METRICS_ENVIRONMENT_VERSION: [2](https://github.com/metal-stack/metal-images/actions/runs/15294259709/job/43019516109#step:10:2).1.4
accepts 1 arg(s), received 2
``` 

Also the "additional-args" does not exist.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
