### PR TITLE
Install Containerd from github release

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_OS_NAME
-ARG BASE_OS_VERSION
+ARG BASE_OS_NAME=debian
+ARG BASE_OS_VERSION=12
 
 FROM golang:1.22-bookworm AS ignition-builder
 ARG IGNITION_BRANCH
@@ -19,8 +19,6 @@ FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 ARG FRR_VERSION
 ARG FRR_VERSION_DETAIL
 ARG GOLLDPD_VERSION
-ARG DOCKER_APT_OS
-ARG DOCKER_APT_CHANNEL
 ARG FRR_APT_CHANNEL
 ARG CRI_VERSION
 ARG SEMVER_MAJOR_MINOR
@@ -28,10 +26,11 @@ ARG KERNEL_VERSION
 ARG UBUNTU_MAINLINE_KERNEL_VERSION
 ARG ICE_VERSION
 ARG ICE_PKG_VERSION
+ARG CONTAINERD_VERSION
+ARG RUNC_VERSION
 
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
-    DOCKER_URL=https://download.docker.com \
     SEMVER_MAJOR_MINOR=${SEMVER_MAJOR_MINOR} \
     UBUNTU_MAINLINE_KERNEL_VERSION=${UBUNTU_MAINLINE_KERNEL_VERSION}
 
@@ -90,10 +89,14 @@ RUN set -ex \
  && userdel -f ubuntu || true \
  && curl -fLsS https://github.com/metal-stack/go-lldpd/releases/download/${GOLLDPD_VERSION}/go-lldpd.tgz -o /tmp/go-lldpd.tgz \
  && tar -xf /tmp/go-lldpd.tgz \
- && curl -fLsS ${DOCKER_URL}/linux/${DOCKER_APT_OS}/gpg | apt-key add - \
- && echo "deb [arch=amd64] ${DOCKER_URL}/linux/${DOCKER_APT_OS} ${DOCKER_APT_CHANNEL} stable" > /etc/apt/sources.list.d/docker.list \
- && apt-get update \
- && apt-get install --yes --no-install-recommends containerd.io \
+ # install containerd
+ && curl -fLsS https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-amd64.tar.gz -o /tmp/containerd.tar.gz \
+ && tar -xf /tmp/containerd.tar.gz -C /usr \
+ && mkdir -p /var/bin/containerruntimes /etc/containerd \
+ && ls -l /lib/systemd/system \
+ # install runc
+ && curl -fLsS https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.amd64 -o /usr/bin/runc \
+ && chmod 755 /usr/bin/runc \
  # generate a default containerd config because the one coming with the package prevents GNA to create a proper config for cgroup v2
  && /usr/bin/containerd config default > /etc/containerd/config.toml \
  # Install crictl to be able to manipulate containers managed with containerd

--- a/debian/context/etc/systemd/system/containerd.service
+++ b/debian/context/etc/systemd/system/containerd.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+
+[Service]
+#uncomment to enable the experimental sbservice (sandboxed) version of containerd/cri integration
+#Environment="ENABLE_CRI_SANDBOXES=sandboxed"
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Environment="PATH=/var/bin/containerruntimes:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/debian/docker-make.debian.yaml
+++ b/debian/docker-make.debian.yaml
@@ -9,11 +9,13 @@ default-build-args:
   - SEMVER_PATCH=${SEMVER_PATCH}
   - BASE_OS_NAME=debian
   - OS_NAME=debian
-  - DOCKER_APT_OS=debian
   - CRI_VERSION=v1.33.0
   - ICE_VERSION=1.14.13
   - ICE_PKG_VERSION=1.3.36.0
   - CIS_VERSION=v4.1-4
+  - CONTAINERD_VERSION=2.1.3
+  - RUNC_VERSION=1.3.0
+
 builds:
   -
     name: "Debian 12"
@@ -21,7 +23,6 @@ builds:
       - ${SEMVER}
     build-args:
       - BASE_OS_VERSION=bookworm
-      - DOCKER_APT_CHANNEL=bookworm
       - FRR_VERSION=frr-stable
       - FRR_VERSION_DETAIL=10.3.1-0~deb12u1
       - FRR_APT_CHANNEL=bookworm

--- a/debian/docker-make.ubuntu.yaml
+++ b/debian/docker-make.ubuntu.yaml
@@ -9,13 +9,13 @@ default-build-args:
   - SEMVER_PATCH=${SEMVER_PATCH}
   - BASE_OS_NAME=ubuntu
   - OS_NAME=ubuntu
-  - DOCKER_APT_OS=ubuntu
-  - DOCKER_APT_CHANNEL=noble
   - CRI_VERSION=v1.33.0
   # see https://kernel.ubuntu.com/mainline for available versions
   - UBUNTU_MAINLINE_KERNEL_VERSION=v6.12.34
   - ICE_VERSION=1.14.13
   - ICE_PKG_VERSION=1.3.36.0
+  - CONTAINERD_VERSION=2.1.3
+  - RUNC_VERSION=1.3.0
 
 builds:
   -


### PR DESCRIPTION
## Description

Change containerd installation to download from gh release and untar in preparation to migrate to v2.
Also make the installation less distribution dependent, the way it has to be installed from the docker repos changed with debian 13 and differs for ubuntu. With this approach its identical.


Also did some early tests with v2m but this has to wait until we must not support k8s v1.29.x

Since Gardener 1.115 containerd v2.x is supported.

TODO:

- [x] test with oldest possible k8s version

Works:

```
 $ k get node -o wide
NAME                                        STATUS   ROLES   AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                         KERNEL-VERSION   CONTAINER-RUNTIME
shoot--pnnvns--stefan-group-0-69dd6-7mhmx   Ready    node    4m19s   v1.32.6   10.128.32.2   <none>        Debian GNU/Linux 12 (bookworm)   6.1.0-37-amd64   containerd://2.1.3
```

One Warning remains:

```
Jul 04 16:31:11 shoot--pnnvns--stefan-group-0-69dd6-7mhmx health-monitor-containerd[12439]: time="2025-07-04T16:31:11+02:00" level=warning msg="DEPRECATION: The `bin_dir` property of `[plugins.\"io.containerd.cri.v1.runtime\".cni`] is deprecated since containerd v2.1 and will be removed in containerd v2.2. Use `bin_dirs` in the same section instead."

```

According to: https://github.com/containerd/containerd/blob/v2.0.0/RELEASES.md#kubernetes-support it is recommended to use containerd v2.x for kubernetes >= v1.30.x.

We wait until we reached this.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
