### PR TITLE
Use systemd generator functionality for enabling getty instances

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -159,7 +159,6 @@ RUN systemctl set-default multi-user.target \
                      systemd-timesyncd \
                      watchdog.service \
                      cloud-init-custom.service \
-                     serial-getty@ttyS1.service \
  && systemctl disable console-getty.service \
  && systemctl mask console-getty.service \
  && update-ca-certificates \


### PR DESCRIPTION
## Description

Previously, the `serial-getty@ttyS1.service` was enabled manually. However, systemd has the `systemd-getty-generator`, which checks `/sys/class/tty/console/active` and creates an instance of the `serial-getty@.service` e.g. serial-getty@ttyS1.service. The file `/sys/class/tty/console/active` reflects `ttySx` passed as kernel command line arguments via `console=`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
