### PR TITLE
Stay with frr-10.4.x for now

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -50,7 +50,7 @@ target "debian" {
         BASE_OS_VERSION = "bookworm"
         DOCKER_APT_OS = "debian"
         DOCKER_APT_CHANNEL ="bookworm"
-        FRR_VERSION ="frr-10"
+        FRR_VERSION ="frr-10.4"
         FRR_VERSION_DETAIL ="10.4.1-0~deb12u1"
         FRR_APT_CHANNEL ="bookworm"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
@@ -91,7 +91,7 @@ target "ubuntu" {
         BASE_OS_VERSION = "24.04"
         DOCKER_APT_OS = "ubuntu"
         DOCKER_APT_CHANNEL ="noble"
-        FRR_VERSION ="frr-10"
+        FRR_VERSION ="frr-10.4"
         FRR_VERSION_DETAIL ="10.4.1-0~ubuntu24.04.1"
         FRR_APT_CHANNEL ="noble"
         # see https://kernel.ubuntu.com/mainline for available versions


### PR DESCRIPTION
## Description

Frr 10.5 was released this week which removed frr-10.4.x from the frr-10 stable repo, fix this

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
