### PR TITLE
Use our frr build v10.4.1 instead of upstream 10.4.3

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,8 @@
 ARG BASE_OS_NAME=debian
 ARG BASE_OS_VERSION=bookworm
+ARG FRR_TAG=10.4.1-debian-12
+
+FROM ghcr.io/metal-stack/frr:${FRR_TAG} AS frr-artifacts
 
 FROM golang:1.22-bookworm AS ignition-builder
 ARG IGNITION_BRANCH
@@ -16,12 +19,9 @@ RUN set -ex \
 FROM ${BASE_OS_NAME}:${BASE_OS_VERSION}
 # Beware, ARGs for ENV variables except FROM line must be below FROM
 
-ARG FRR_VERSION
-ARG FRR_VERSION_DETAIL
 ARG GOLLDPD_VERSION
 ARG DOCKER_APT_OS
 ARG DOCKER_APT_CHANNEL
-ARG FRR_APT_CHANNEL
 ARG CRI_VERSION
 ARG KERNEL_VERSION
 ARG UBUNTU_MAINLINE_KERNEL_VERSION
@@ -37,6 +37,7 @@ ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
 COPY --from=ctx etc/initramfs-tools/conf.d/ /etc/initramfs-tools/conf.d/
 COPY --from=ignition-builder /work/ignition/bin/amd64/ignition* /usr/local/bin/
 COPY --from=ctx kernel-installation.sh /
+COPY --from=frr-artifacts /artifacts/*.deb /tmp/
 
 RUN set -ex \
  && rm -f /.dockerenv \
@@ -105,11 +106,8 @@ RUN set -ex \
  # Switch to use iptables-legacy on worker nodes
  && update-alternatives --set iptables /usr/sbin/iptables-legacy \
  && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
- # install frr from frrouting debian package repo
- && curl -s https://deb.frrouting.org/frr/keys.gpg | tee /usr/share/keyrings/frrouting.gpg > /dev/null \
- && echo "deb [signed-by=/usr/share/keyrings/frrouting.gpg] https://deb.frrouting.org/frr ${FRR_APT_CHANNEL} ${FRR_VERSION}" > /etc/apt/sources.list.d/frr.list \
- && apt update \
- && apt install --yes --no-install-recommends frr=${FRR_VERSION_DETAIL} frr-pythontools=${FRR_VERSION_DETAIL} \
+ # Forcefully install frr from our own builds because upstream repo removes older patch versions
+ && apt install --yes --allow-downgrades /tmp/*.deb \
  # Install Intel Firmware for e800 based network cards
  && curl -fLsS https://github.com/intel/ethernet-linux-ice/releases/download/v${ICE_VERSION}/ice-${ICE_VERSION}.tar.gz -o ice.tar.gz \
  && tar -xf ice.tar.gz ice-${ICE_VERSION}/ddp/ice-${ICE_PKG_VERSION}.pkg \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -49,9 +49,7 @@ target "debian" {
         BASE_OS_VERSION = "bookworm"
         DOCKER_APT_OS = "debian"
         DOCKER_APT_CHANNEL ="bookworm"
-        FRR_VERSION ="frr-10.4"
-        FRR_VERSION_DETAIL ="10.4.3-0~deb12u1"
-        FRR_APT_CHANNEL ="bookworm"
+        FRR_TAG = "10.4.1-debian-12"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
       # upgrade to > 6.1.0-40 actually not possible because it breaks calico:
       # see https://github.com/projectcalico/calico/issues/11302#issuecomment-3526431095
@@ -93,9 +91,7 @@ target "ubuntu" {
         BASE_OS_VERSION = "24.04"
         DOCKER_APT_OS = "ubuntu"
         DOCKER_APT_CHANNEL ="noble"
-        FRR_VERSION ="frr-10.4"
-        FRR_VERSION_DETAIL ="10.4.3-0~ubuntu24.04.1"
-        FRR_APT_CHANNEL ="noble"
+        FRR_TAG = "10.4.1-ubuntu-24.04"
         # see https://kernel.ubuntu.com/mainline for available versions
         UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.74"
         CONTAINERD_VERSION = "2.1.5-1~ubuntu.24.04~noble"

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -2,12 +2,13 @@ ARG DROPTAILER_VERSION=v0.2.19
 ARG FIREWALL_CONTROLLER_VERSION=v2.4.2
 ARG TAILSCALE_VERSION=v1.90.6
 ARG NODE_EXPORTER_VERSION=v1.10.2
+ARG FRR_TAG=10.4.1-ubuntu-24.04
 
 FROM ghcr.io/metal-stack/droptailer-client:${DROPTAILER_VERSION} AS droptailer-artifacts
 
 FROM ghcr.io/metal-stack/firewall-controller:${FIREWALL_CONTROLLER_VERSION} AS firewall-controller-artifacts
 
-FROM ghcr.io/metal-stack/frr:10.4.1-ubuntu-24.04 AS frr-artifacts
+FROM ghcr.io/metal-stack/frr:${FRR_TAG} AS frr-artifacts
 
 FROM ghcr.io/tailscale/tailscale:${TAILSCALE_VERSION} AS tailscale-artifacts
 


### PR DESCRIPTION
## Description

Use our build of frr instead of the upstream packages because we have connectivity regressions with 10.4.3 compared to 10.4.1.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
