### PR TITLE
Increase LimitNOFILE for container 2.1 to previous value from containerd 1.7

### DIFF
--- a/debian/context/etc/systemd/system/containerd.service.d/40-ulimit.conf
+++ b/debian/context/etc/systemd/system/containerd.service.d/40-ulimit.conf
@@ -1,4 +1,3 @@
 [Service]
-LimitNOFILE=1048576
 LimitNPROC=infinity
-
+LimitNOFILE=1048576


### PR DESCRIPTION
## Description

containerd 2.1 changed the max open file to 1024.
This PR brings back the old value of 1048576

```
< Max open files            1048576              1048576              files
---
> Max open files            1024                 524288               files

```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
