### PR TITLE
chore(capms): bump to v1.34.5

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -173,7 +173,7 @@ jobs:
         shell: bash
         run: ./prepare.sh capms-ubuntu
         env:
-          SEMVER_MAJOR_MINOR: 1.32.9
+          SEMVER_MAJOR_MINOR: 1.34.5
         if: ${{ matrix.os.name == 'ubuntu' }}
 
       - name: Build docker image for capms
@@ -185,10 +185,10 @@ jobs:
           no-cache: true
           set: _common.output+=type=registry
         env:
-          KUBE_VERSION: 1.32.9
-          KUBE_APT_BRANCH: v1.32
+          KUBE_VERSION: 1.34.5
+          KUBE_APT_BRANCH: v1.34
           OS_NAME: capms-ubuntu
-          SEMVER_MAJOR_MINOR: 1.32.9
+          SEMVER_MAJOR_MINOR: 1.34.5
           SEMVER_PATCH: ${{ env.SEMVER_PATCH }}
         if: ${{ matrix.os.name == 'ubuntu' }}
 
@@ -199,7 +199,7 @@ jobs:
         env:
           IMG_PKG_COMMAND: dpkg -l
           OS_NAME: capms-ubuntu
-          SEMVER_MAJOR_MINOR: 1.32.9
+          SEMVER_MAJOR_MINOR: 1.34.5
           SEMVER_PATCH: ${{ env.SEMVER_PATCH }}
         if: ${{ matrix.os.name == 'ubuntu' }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           DISTRO_VERSIONS: |
             [
               "ubuntu/24.04",
-              "capms-ubuntu/1.32.9",
+              "capms-ubuntu/1.34.5",
               "firewall/3.0-ubuntu",
               "debian/12",
               "debian-nvidia/12",

--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,11 @@ ubuntu: test binary
 
 .PHONY: capms
 capms: test ubuntu
-	KUBE_VERSION=1.32.9 \
-	KUBE_APT_BRANCH=v1.32 \
-	SEMVER_MAJOR_MINOR=1.32.9 \
+	KUBE_VERSION=1.34.5 \
+	KUBE_APT_BRANCH=v1.34 \
+	SEMVER_MAJOR_MINOR=1.34.5 \
 	docker buildx bake --no-cache ubuntu-capms
-	OS_NAME=capms-ubuntu OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=1.32.9 ./test.sh
+	OS_NAME=capms-ubuntu OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=1.34.5 ./test.sh
 
 .PHONY: firewall
 firewall: test binary

--- a/cmd/tools/handle-release/README.md
+++ b/cmd/tools/handle-release/README.md
@@ -5,6 +5,6 @@
 ```bash
 FILENAME=downloads.md \
 REF_NAME=$(git rev-parse --abbrev-ref HEAD) \
-DISTRO_VERSIONS=$'["capms-ubuntu/1.32.9", "ubuntu/24.04", "almalinux/9"]' \
+DISTRO_VERSIONS=$'["capms-ubuntu/1.34.5", "ubuntu/24.04", "almalinux/9"]' \
 go run . --dry-run
 ```


### PR DESCRIPTION
## Description

Bumps k8s version from the EOF v1.32 to the latest v1.34.5 we support (v1.35 requires https://github.com/metal-stack/cluster-api-provider-metal-stack/issues/125).
I decided to skip v1.33 for now.

Supersedes #377 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
