### PR TITLE
update kernels (dirtyfrag, CVE-2026-43284, CVE-2026-43500)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,7 +53,7 @@ target "debian" {
         FRR_VERSION_DETAIL ="10.4.4-0~deb12u1"
         FRR_APT_CHANNEL ="bookworm"
       # see https://packages.debian.org/bookworm/kernel/ for available versions
-        KERNEL_VERSION = "6.1.0-45"
+        KERNEL_VERSION = "6.1.0-47"
         CONTAINERD_VERSION = "2.1.5-1~debian.12~bookworm"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
@@ -95,7 +95,7 @@ target "ubuntu" {
         FRR_VERSION_DETAIL ="10.4.4-0~ubuntu24.04.1"
         FRR_APT_CHANNEL ="noble"
         # see https://kernel.ubuntu.com/mainline for available versions
-        UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.85"
+        UBUNTU_MAINLINE_KERNEL_VERSION = "v6.12.87"
         CONTAINERD_VERSION = "2.1.5-1~ubuntu.24.04~noble"
     }
     tags = ["ghcr.io/metal-stack/ubuntu:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]


### PR DESCRIPTION
## Description
Update kernels (dirtyfrag, CVE-2026-43284, CVE-2026-43500). As with copyfail, current Debian images are unaffected.