### PR TITLE
Update firewall-controller and tools

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,7 +18,7 @@ target "_common_args" {
     args = {
         IGNITION_BRANCH = "v0.36.2"
         GOLLDPD_VERSION = "v0.4.12"
-        CRI_VERSION = "v1.35.0"
+        CRI_VERSION = "v1.36.0"
         ICE_VERSION = "2.4.5"
         ICE_PKG_VERSION = "1.3.53.0"
     }

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -1,6 +1,6 @@
-ARG DROPTAILER_VERSION=v0.2.19
-ARG FIREWALL_CONTROLLER_VERSION=v2.4.2
-ARG TAILSCALE_VERSION=v1.90.6
+ARG DROPTAILER_VERSION=v0.2.20
+ARG FIREWALL_CONTROLLER_VERSION=v2.5.0
+ARG TAILSCALE_VERSION=v1.98.4
 ARG NODE_EXPORTER_VERSION=v1.11.1
 
 FROM ghcr.io/metal-stack/droptailer-client:${DROPTAILER_VERSION} AS droptailer-artifacts
@@ -17,7 +17,7 @@ FROM baseapp
 
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
-    NFTABLES_EXPORTER_VERSION=v0.4.3
+    NFTABLES_EXPORTER_VERSION=v0.4.5
 
 # iptables reinstallation is required, so that image works in mini-lab environment.
 # Most likely the reason is that old config is removed during deletion.


### PR DESCRIPTION
## Description

With this:

- DROPTAILER_VERSION=v0.2.20
- FIREWALL_CONTROLLER_VERSION=v2.5.0
- TAILSCALE_VERSION=v1.98.4
- NFTABLES_EXPORTER_VERSION=v0.4.5

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
