### PR TITLE
Replace ubuntu firewall with debian (backports kernel)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -139,25 +139,23 @@ jobs:
         shell: bash
         run: ./prepare.sh firewall
         env:
-          SEMVER_MAJOR_MINOR: 3.0-ubuntu
-        if: ${{ matrix.os.name == 'ubuntu' }}
+          SEMVER_MAJOR_MINOR: 3.0
+        if: ${{ matrix.os.name == 'debian' }}
 
       - name: Build docker image for firewalls
         uses: docker/bake-action@v7
         with:
           source: .
           files: ./docker-bake.hcl
-          targets: ubuntu-firewall
+          targets: debian-firewall
           no-cache: true
           set: _common.output+=type=registry
         env:
           OS_NAME: firewall
-          SEMVER_MAJOR_MINOR: 3.0-ubuntu
+          SEMVER_MAJOR_MINOR: 3.0
           SEMVER_PATCH: ${{ env.SEMVER_PATCH }}
-        if: ${{ matrix.os.name == 'ubuntu' }}
+        if: ${{ matrix.os.name == 'debian' }}
 
-      # TODO enable debian build again, actually droptailer and firewall-controller did not get enabled
-      # and then goss tests fail
       - name: Test and export docker image for firewalls
         run: |
           ./test.sh
@@ -165,9 +163,9 @@ jobs:
         env:
           IMG_PKG_COMMAND: dpkg -l
           OS_NAME: firewall
-          SEMVER_MAJOR_MINOR: 3.0-ubuntu
+          SEMVER_MAJOR_MINOR: 3.0
           SEMVER_PATCH: ${{ env.SEMVER_PATCH }}
-        if: ${{ matrix.os.name == 'ubuntu' }}
+        if: ${{ matrix.os.name == 'debian' }}
 
       - name: Prepare build environment
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
             [
               "ubuntu/26.04",
               "capms-ubuntu/1.32.9",
-              "firewall/3.0-ubuntu",
+              "firewall/3.0",
               "debian/13",
               "debian-nvidia/13",
               "almalinux/10"

--- a/IMAGE_STORE.md
+++ b/IMAGE_STORE.md
@@ -11,7 +11,7 @@ The actual directory layout should look like:
 
 Where `<imagesdir>` is `stable` for the master branch, `<patch>` for releases and `pull_requests/<pr-number>-<branch-name>` for pull requests.
 
-`<os>` is the name of the os in use, some images like `firewall` are derived from another os image (in this case the `ubuntu` image).
+`<os>` is the name of the os in use, some images like `firewall` are derived from another os image (in this case the `debian` image).
 
 `<major.minor>` specifies the major and minor number of the OS, which is case of ubuntu "19.10", "19.10", "20.04" and so on. This version must follow the semantic versioning specification, whereas we tolerate a leading zero for the minor version which is quite common for some OSes.
 

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,9 @@ capms: test ubuntu
 
 .PHONY: firewall
 firewall: test binary
-	mkdir -p "images/firewall/3.0-ubuntu"
-	OS_NAME=firewall OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=3.0-ubuntu docker buildx bake --no-cache ubuntu-firewall
-	OS_NAME=firewall OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=3.0-ubuntu ./test.sh
+	mkdir -p "images/firewall/3.0"
+	OS_NAME=firewall OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=3.0 docker buildx bake --no-cache debian-firewall
+	OS_NAME=firewall OUTPUT_FOLDER="" SEMVER_MAJOR_MINOR=3.0 ./test.sh
 
 .PHONY: almalinux
 almalinux: test binary

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently these images are supported:
 
 1. Debian 13
 1. Ubuntu 26.04
-1. Firewall 3.0-ubuntu (based on Ubuntu 26.04)
+1. Firewall 3.0 (based on Debian 13)
 1. Nvidia (based on Debian 13)
 
 ## Unsupported Images

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -101,16 +101,6 @@ target "ubuntu" {
     tags = ["ghcr.io/metal-stack/ubuntu:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }
 
-target "ubuntu-firewall" {
-    inherits = ["_common"]
-    dockerfile = "./firewall/Dockerfile"
-    contexts = {
-        baseapp = "target:ubuntu"
-        ctx = "./firewall/context"
-    }
-    tags = ["ghcr.io/metal-stack/firewall:3.0-ubuntu${SEMVER_PATCH}"]
-}
-
 variable "KUBE_VERSION" {}
 variable "KUBE_APT_BRANCH" {}
 

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -7,7 +7,7 @@ FROM ghcr.io/metal-stack/droptailer-client:${DROPTAILER_VERSION} AS droptailer-a
 
 FROM ghcr.io/metal-stack/firewall-controller:${FIREWALL_CONTROLLER_VERSION} AS firewall-controller-artifacts
 
-FROM ghcr.io/metal-stack/frr:10.4.1-ubuntu-24.04 AS frr-artifacts
+FROM ghcr.io/metal-stack/frr:10.4.1-debian-12 AS frr-artifacts
 
 FROM ghcr.io/tailscale/tailscale:${TAILSCALE_VERSION} AS tailscale-artifacts
 
@@ -18,6 +18,15 @@ FROM baseapp
 ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NFTABLES_EXPORTER_VERSION=v0.4.5
+
+# Install newer kernel from trixie-backports for VRF/nftables fixes not in 6.12
+RUN echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/backports.list \
+ && apt-get update --quiet \
+ && apt-get remove --yes linux-image-* \
+ && apt-get install --yes -t trixie-backports linux-image-amd64 \
+ && rm -f /etc/apt/sources.list.d/backports.list \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # iptables reinstallation is required, so that image works in mini-lab environment.
 # Most likely the reason is that old config is removed during deletion.

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ set -ex
 # WORKS 					OS_NAME=debian CIS_VERSION=v4.1-4 ./test.sh ghcr.io/metal-stack/debian:13-stable
 # WORKS_WITH_METAL_KERNEL   OS_NAME=debian-nvidia ./test.sh ghcr.io/metal-stack/debian-nvidia:13-stable
 # WORKS_WITH_METAL_KERNEL   OS_NAME=debian ./test.sh ghcr.io/metal-stack/debian:13-stable
-# WORKS					    OS_NAME=firewall ./test.sh ghcr.io/metal-stack/firewall:3.0-ubuntu-stable
+# WORKS					    OS_NAME=firewall ./test.sh ghcr.io/metal-stack/firewall:3.0-stable
 # WORKS                     OS_NAME=almalinux ./test.sh ghcr.io/metal-stack/almalinux:10-stable
 
 export MACHINE_TYPE="machine"

--- a/test/01_start_vm.sh
+++ b/test/01_start_vm.sh
@@ -17,10 +17,7 @@ ip link set tap0 master vm-br0 || true
 if [[ "${OS_NAME}" == "ubuntu" || "${OS_NAME}" == "capms-ubuntu" ]]; then
   INITRAMFS=""
   KERNEL="os-kernel"
-elif [[ "${OS_NAME}" == *"firewall" ]]; then
-  INITRAMFS=""
-  KERNEL="os-kernel"
-elif [[ "${OS_NAME}" == "debian" || "${OS_NAME}" == "debian-nvidia" ]]; then
+elif [[ "${OS_NAME}" == "debian" || "${OS_NAME}" == "debian-nvidia"  || "${OS_NAME}" == "firewall" ]]; then
   INITRAMFS=""
   KERNEL="metal-kernel"
 else


### PR DESCRIPTION
## Description

This replaces ubuntu based firewall images with debian based images. To avoid known issues with the debian kernel, the backports kernel (6.17+) is used.

This PR still needs thorough testing.

#### Used AI-Tools ✨

None

## Release Notes

### Required Actions

```ACTIONS_REQUIRED
metal-stack will no longer provide ubuntu based firewall-images, please use the debian based sucessor
```