### PR TITLE
Update containerd on debian

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,7 +54,7 @@ target "debian" {
         FRR_APT_CHANNEL ="trixie"
       # see https://packages.debian.org/trixie/kernel/ for available versions
         KERNEL_VERSION = "6.12.95+deb13"
-        CONTAINERD_VERSION = "2.1.5-1~debian.13~trixie"
+        CONTAINERD_VERSION = "2.2.5-1~debian.13~trixie"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,7 +54,7 @@ target "debian" {
         FRR_APT_CHANNEL ="trixie"
       # see https://packages.debian.org/trixie/kernel/ for available versions
         KERNEL_VERSION = "6.12.95+deb13"
-        CONTAINERD_VERSION = "2.2.5-1~debian.13~trixie"
+        CONTAINERD_VERSION = "2.2.6-1~debian.13~trixie"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }
@@ -96,7 +96,7 @@ target "ubuntu" {
         FRR_APT_CHANNEL ="noble"
         # see https://kernel.ubuntu.com/mainline for available versions
         UBUNTU_MAINLINE_KERNEL_VERSION = "v6.18.38"
-        CONTAINERD_VERSION = "2.2.5-1~ubuntu.26.04~resolute"
+        CONTAINERD_VERSION = "2.2.6-1~ubuntu.26.04~resolute"
     }
     tags = ["ghcr.io/metal-stack/ubuntu:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,13 +53,8 @@ target "debian" {
         FRR_VERSION_DETAIL ="10.4.4-0~deb13u1"
         FRR_APT_CHANNEL ="trixie"
       # see https://packages.debian.org/trixie/kernel/ for available versions
-<<<<<<< HEAD
-        KERNEL_VERSION = "6.12.95+deb13"
-        CONTAINERD_VERSION = "2.2.6-1~debian.13~trixie"
-=======
         KERNEL_VERSION = "6.12.96+deb13"
-        CONTAINERD_VERSION = "2.1.5-1~debian.13~trixie"
->>>>>>> 65fc9c7193bb556cf24aaf85cb2eb6ad9cd55cb2
+        CONTAINERD_VERSION = "2.2.6-1~debian.13~trixie"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }


### PR DESCRIPTION
## Description

According to https://containerd.io/releases/ containerd v2.1.x ended support on 3.July 2026, use v2.2.x instead now.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
