### PR TITLE
Speedup single stream network performance

### DIFF
--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -54,7 +54,10 @@ RUN systemctl disable chrony \
  && mv /lib/systemd/system/chrony.service /lib/systemd/system/chrony@.service \
  && systemctl enable nftables \
  && systemctl enable fever \
- && systemctl enable frr.service
+ && systemctl enable frr.service \
+ && systemctl enable ethtool-lan0.service \
+ && systemctl enable ethtool-lan1.service
+ 
 
 # Fix permissions of systemd service files
 RUN chmod 0644 /lib/systemd/system/*.service

--- a/firewall/context/etc/systemd/system/ethtool-lan0.service
+++ b/firewall/context/etc/systemd/system/ethtool-lan0.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable TSO on lan0
+After=network.target sys-subsystem-net-devices-lan0.device
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ethtool -K lan0 tx-checksum-ipv4 off
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/firewall/context/etc/systemd/system/ethtool-lan1.service
+++ b/firewall/context/etc/systemd/system/ethtool-lan1.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Disable TSO on lan1
+After=network.target sys-subsystem-net-devices-lan1.device
+Wants=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ethtool -K lan1 tx-checksum-ipv4 off
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Single stream network performance was too low.

KI Identified the root cause as:

```
Root cause

The ice driver advertises outer-UDP checksum offload for VXLAN but computes it incorrectly. Known upstream: OpenVSwitch disables it unconditionally for ice/i40e; DPDK carries fixes (2020, 2023); same symptom in Calico #4865/#7040, flannel #1279, kubespray #8992, F5 ID509310.

The tunnel-specific knobs do not help — the offending feature is plain tx-checksum-ipv4.

Proposed workaround

ethtool -K lan0 tx off
```


#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- Deepseek used for root cause analysis, implementation was done manually

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
