### PR TITLE
Remove iptables and fever

### DIFF
--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -20,7 +20,9 @@ ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     NFTABLES_EXPORTER_VERSION=v0.4.5
 
 # Install bridge-utils as a requirement for frr
+# remove iptables as it is not required anymore from tailscale
 RUN apt-get update --quiet \
+ && apt-get remove --yes iptables \
  && apt-get install --yes \
     bridge-utils
 

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -19,16 +19,6 @@ ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NFTABLES_EXPORTER_VERSION=v0.4.5
 
-# iptables reinstallation is required, so that image works in mini-lab environment.
-# Most likely the reason is that old config is removed during deletion.
-RUN apt-get update --quiet \
- && apt-get install --yes \
-    bridge-utils \
-    fever \
-    tcpdump \
- && apt-get remove --yes iptables \
- && apt install --yes iptables
-
 # Forcefully install frr from our own builds because upstream repo removes older patch versions
 COPY --from=frr-artifacts /artifacts/*.deb /tmp/
 RUN apt remove --yes frr* \
@@ -53,7 +43,6 @@ RUN systemctl disable chrony \
  && echo chrony > /etc/vrf/systemd.conf \
  && mv /lib/systemd/system/chrony.service /lib/systemd/system/chrony@.service \
  && systemctl enable nftables \
- && systemctl enable fever \
  && systemctl enable frr.service \
  && systemctl enable ethtool-lan0.service \
  && systemctl enable ethtool-lan1.service

--- a/firewall/Dockerfile
+++ b/firewall/Dockerfile
@@ -19,6 +19,11 @@ ENV DEBCONF_NONINTERACTIVE_SEEN="true" \
     DEBIAN_FRONTEND="noninteractive" \
     NFTABLES_EXPORTER_VERSION=v0.4.5
 
+# Install bridge-utils as a requirement for frr
+RUN apt-get update --quiet \
+ && apt-get install --yes \
+    bridge-utils
+
 # Forcefully install frr from our own builds because upstream repo removes older patch versions
 COPY --from=frr-artifacts /artifacts/*.deb /tmp/
 RUN apt remove --yes frr* \


### PR DESCRIPTION
## Description

- since Dec 2025 tailscale does not require iptables anymore, so remove it.
- tcpdump is already installed in the base system
- fever is not really used

TODO:

- [x] test if tailscale still works

```bash
$ sudo journalctl -lu tailscaled | grep tables
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[879]: linuxfw: clear iptables: exec: "iptables": executable file not found in $PATH
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[879]: linuxfw: clear ip6tables: exec: "ip6tables": executable file not found in $PATH
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[944]: linuxfw: clear iptables: exec: "iptables": executable file not found in $PATH
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[944]: linuxfw: clear ip6tables: exec: "ip6tables": executable file not found in $PATH
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[944]: router: iptables not found: firewall mode "iptables" not supported: iptables command run fail: exec: "iptables": executable file not found in $PATH
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[944]: exec: "ip6tables": executable file not found in $PATH; falling back to nftables
Jul 28 11:29:06 shoot--pnnvns--stefan-firewall-b6b3b ip[944]: router: netfilter running in nftables mode, v6 = true
$ sudo iptables
sudo: iptables: command not found

```



#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
