### PR TITLE
 update containerd to 2.3.x

### DIFF
--- a/almalinux/Dockerfile
+++ b/almalinux/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_OS_VERSION=10
 
-FROM golang:1.22-bullseye AS ignition-builder
+FROM golang:1.22-bookworm AS ignition-builder
 ARG IGNITION_BRANCH
 WORKDIR /work
 RUN set -ex \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,7 +54,7 @@ target "debian" {
         FRR_APT_CHANNEL ="trixie"
       # see https://packages.debian.org/trixie/kernel/ for available versions
         KERNEL_VERSION = "6.12.107+deb13"
-        CONTAINERD_VERSION = "2.2.6-1~debian.13~trixie"
+        CONTAINERD_VERSION = "2.3.5-1~debian.13~trixie"
     }
     tags = ["ghcr.io/metal-stack/debian:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }
@@ -96,7 +96,7 @@ target "ubuntu" {
         FRR_APT_CHANNEL ="resolute"
         # see https://kernel.ubuntu.com/mainline for available versions
         UBUNTU_MAINLINE_KERNEL_VERSION = "v6.18.48"
-        CONTAINERD_VERSION = "2.2.6-1~ubuntu.26.04~resolute"
+        CONTAINERD_VERSION = "2.3.5-1~ubuntu.26.04~resolute"
     }
     tags = ["ghcr.io/metal-stack/ubuntu:${SEMVER_MAJOR_MINOR}${SEMVER_PATCH}"]
 }


### PR DESCRIPTION
## Description

Requires [gardener v1.144.0](https://github.com/gardener/gardener/releases/tag/v1.144.0)
